### PR TITLE
fix: Update CICD.yml

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -61,7 +61,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Notify success on Discord
-        if: success()
+        if: success() && github.repository == 'Kernel360/KBE5_HomeAid_BE'
         run: |
           curl -H "Content-Type: application/json" \
                -X POST \
@@ -76,7 +76,7 @@ jobs:
                ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Notify failure on Discord
-        if: failure()
+        if: failure() && github.repository == 'Kernel360/KBE5_HomeAid_BE'
         run: |
           curl -H "Content-Type: application/json" \
                -X POST \

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -7,6 +7,7 @@ on:
     branches: [ dev ]
   pull_request_target:
     branches: [ dev ]  # fork PR secrets 사용 가능
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-and-test:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -5,6 +5,8 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+  pull_request_target:
+    branches: [ dev ]  # fork PR secrets 사용 가능
 
 jobs:
   build-and-test:
@@ -29,6 +31,14 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+        if: github.event_name == 'pull_request_target'
+
+      - name: Checkout source code (for push/pull_request)
+        uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
 
       - name: Set up JDK 17 (corretto)
         uses: actions/setup-java@v3


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- fork 저장소에서 PR을 보낼 때 GitHub Actions에서 secrets가 주입되지 않아 Discord 알림 및 DB 인증이 실패하던 문제를 해결했습니다.
- 이를 위해 pull_request_target 이벤트를 도입하고, fork PR의 커밋을 수동으로 checkout 하도록 처리했습니다.
- secrets를 사용하는 단계는 본 저장소에서만 실행되도록 분기 처리를 추가하여 보안상 이슈를 방지했습니다.

## ✏️ 변경 사항
- pull_request_target 이벤트 추가
- fork PR의 커밋을 checkout 하기 위한 ref 및 repository 설정 추가
- fork 환경에서도 정상적으로 CI를 실행할 수 있도록 워크플로 수정
