### PR TITLE
유저 entity 설계 및 생성

### DIFF
--- a/src/main/java/com/example/homeaid/HomeAidApplication.java
+++ b/src/main/java/com/example/homeaid/HomeAidApplication.java
@@ -2,8 +2,10 @@ package com.example.homeaid;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HomeAidApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/homeaid/customer/entity/Customer.java
+++ b/src/main/java/com/example/homeaid/customer/entity/Customer.java
@@ -2,21 +2,22 @@ package com.example.homeaid.customer.entity;
 
 
 import com.example.homeaid.global.common.entity.User;
+import com.example.homeaid.global.common.entity.enumerate.GenderType;
+import com.example.homeaid.global.common.entity.enumerate.UserRole;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "customer")
 public class Customer extends User {
@@ -24,4 +25,14 @@ public class Customer extends User {
   @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CustomerAddress> addressList = new ArrayList<>();
 
+  public void addAddress(CustomerAddress address) {
+    addressList.add(address);
+    address.setCustomer(this);
+  }
+
+  @Builder
+  public Customer(String email, String password, String name, String phone,
+      LocalDate birth, GenderType gender, UserRole role) {
+    super(email, password, name, phone, birth, gender, role);
+  }
 }

--- a/src/main/java/com/example/homeaid/customer/entity/Customer.java
+++ b/src/main/java/com/example/homeaid/customer/entity/Customer.java
@@ -2,9 +2,26 @@ package com.example.homeaid.customer.entity;
 
 
 import com.example.homeaid.global.common.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
+@Table(name = "customer")
 public class Customer extends User {
+
+  @OneToMany(mappedBy = "customer", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<CustomerAddress> addressList = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/homeaid/customer/entity/Customer.java
+++ b/src/main/java/com/example/homeaid/customer/entity/Customer.java
@@ -1,0 +1,10 @@
+package com.example.homeaid.customer.entity;
+
+
+import com.example.homeaid.global.common.entity.User;
+import jakarta.persistence.Entity;
+
+@Entity
+public class Customer extends User {
+
+}

--- a/src/main/java/com/example/homeaid/customer/entity/CustomerAddress.java
+++ b/src/main/java/com/example/homeaid/customer/entity/CustomerAddress.java
@@ -1,4 +1,4 @@
-package com.example.homeaid.manager.entity;
+package com.example.homeaid.customer.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,8 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,21 +18,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "manager_availability")
-public class ManagerAvailability {
+@Table(name = "customer_address")
+public class CustomerAddress {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "manager_id")
-  private Manager manager;
+  @JoinColumn(name = "customer_id")
+  private Customer customer;
 
-  private LocalDate availableDate;
+  private String address;
 
-  private LocalDateTime availableTime;
-
-  private String region;
-
+  private String addressDetail;
 }

--- a/src/main/java/com/example/homeaid/customer/entity/CustomerAddress.java
+++ b/src/main/java/com/example/homeaid/customer/entity/CustomerAddress.java
@@ -8,15 +8,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "customer_address")
 public class CustomerAddress {
@@ -25,6 +24,7 @@ public class CustomerAddress {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Setter
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "customer_id")
   private Customer customer;
@@ -32,4 +32,10 @@ public class CustomerAddress {
   private String address;
 
   private String addressDetail;
+
+  @Builder
+  public CustomerAddress(String address, String addressDetail) {
+    this.address = address;
+    this.addressDetail = addressDetail;
+  }
 }

--- a/src/main/java/com/example/homeaid/global/common/entity/User.java
+++ b/src/main/java/com/example/homeaid/global/common/entity/User.java
@@ -1,5 +1,6 @@
 package com.example.homeaid.global.common.entity;
 
+import com.example.homeaid.global.common.entity.enumerate.GenderType;
 import com.example.homeaid.global.common.entity.enumerate.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,16 +10,26 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
+@Table(name = "user")
 @Inheritance(strategy = InheritanceType.JOINED)
 @EntityListeners(AuditingEntityListener.class)
 public class User {
@@ -35,6 +46,11 @@ public class User {
   private String name;
 
   private String phone;
+
+  private LocalDate birth;
+
+  @Enumerated(EnumType.STRING)
+  private GenderType gender;
 
   @Enumerated(EnumType.STRING)
   private UserRole role;

--- a/src/main/java/com/example/homeaid/global/common/entity/User.java
+++ b/src/main/java/com/example/homeaid/global/common/entity/User.java
@@ -15,8 +15,6 @@ import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -25,9 +23,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Entity
 @Table(name = "user")
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -41,10 +37,13 @@ public class User {
   @Column(unique = true, nullable = false)
   private String email;
 
+  @Column(nullable = false)
   private String password;
 
+  @Column(nullable = false)
   private String name;
 
+  @Column(nullable = false)
   private String phone;
 
   private LocalDate birth;
@@ -61,5 +60,15 @@ public class User {
 
   @LastModifiedDate
   private LocalDateTime updatedAt;
+
+  public User(String email, String password, String name, String phone, LocalDate birth, GenderType gender, UserRole role) {
+    this.email = email;
+    this.password = password;
+    this.name = name;
+    this.phone = phone;
+    this.birth = birth;
+    this.gender = gender;
+    this.role = role;
+  }
 
 }

--- a/src/main/java/com/example/homeaid/global/common/entity/User.java
+++ b/src/main/java/com/example/homeaid/global/common/entity/User.java
@@ -1,0 +1,49 @@
+package com.example.homeaid.global.common.entity;
+
+import com.example.homeaid.global.common.entity.enumerate.UserRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@EntityListeners(AuditingEntityListener.class)
+public class User {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(unique = true, nullable = false)
+  private String email;
+
+  private String password;
+
+  private String name;
+
+  private String phone;
+
+  @Enumerated(EnumType.STRING)
+  private UserRole role;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/homeaid/global/common/entity/enumerate/GenderType.java
+++ b/src/main/java/com/example/homeaid/global/common/entity/enumerate/GenderType.java
@@ -1,0 +1,5 @@
+package com.example.homeaid.global.common.entity.enumerate;
+
+public enum GenderType {
+  MAIL, FEMALE;
+}

--- a/src/main/java/com/example/homeaid/global/common/entity/enumerate/UserRole.java
+++ b/src/main/java/com/example/homeaid/global/common/entity/enumerate/UserRole.java
@@ -1,0 +1,7 @@
+package com.example.homeaid.global.common.entity.enumerate;
+
+
+public enum UserRole {
+  CUSTOMER, MANAGER, ADMIN;
+
+}

--- a/src/main/java/com/example/homeaid/manager/entity/Manager.java
+++ b/src/main/java/com/example/homeaid/manager/entity/Manager.java
@@ -1,25 +1,30 @@
 package com.example.homeaid.manager.entity;
 
 import com.example.homeaid.global.common.entity.User;
-import com.example.homeaid.manager.entity.enumerated.GenderType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @Entity
+@Table(name = "manager")
 public class Manager extends User {
 
   private String career;
 
   private String experience;
-
-  @Enumerated(EnumType.STRING)
-  private GenderType gender;
 
   private String profileImage;
 

--- a/src/main/java/com/example/homeaid/manager/entity/Manager.java
+++ b/src/main/java/com/example/homeaid/manager/entity/Manager.java
@@ -1,23 +1,25 @@
 package com.example.homeaid.manager.entity;
 
 import com.example.homeaid.global.common.entity.User;
+import com.example.homeaid.global.common.entity.enumerate.GenderType;
+import com.example.homeaid.global.common.entity.enumerate.UserRole;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "manager")
 public class Manager extends User {
@@ -28,13 +30,26 @@ public class Manager extends User {
 
   private String profileImage;
 
+  @Setter
   private String documentUrl;
 
-  private boolean verified = false;
+  private Boolean verified = false;
 
   @OneToMany(mappedBy = "manager", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ManagerAvailability> availabilityList = new ArrayList<>();
 
   private LocalDateTime verifiedAt;
 
+  @Builder
+  public Manager(String email, String password, String name, String phone, LocalDate birth, GenderType gender, String career, String experience, String profileImage) {
+    super(email, password, name, phone, birth, gender, UserRole.MANAGER);
+    this.career = career;
+    this.experience = experience;
+    this.profileImage = profileImage;
+  }
+
+  public void approve() {
+    this.verified = true;
+    this.verifiedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/example/homeaid/manager/entity/Manager.java
+++ b/src/main/java/com/example/homeaid/manager/entity/Manager.java
@@ -1,0 +1,35 @@
+package com.example.homeaid.manager.entity;
+
+import com.example.homeaid.global.common.entity.User;
+import com.example.homeaid.manager.entity.enumerated.GenderType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Manager extends User {
+
+  private String career;
+
+  private String experience;
+
+  @Enumerated(EnumType.STRING)
+  private GenderType gender;
+
+  private String profileImage;
+
+  private String documentUrl;
+
+  private boolean verified = false;
+
+  @OneToMany(mappedBy = "manager", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ManagerAvailability> availabilityList = new ArrayList<>();
+
+  private LocalDateTime verifiedAt;
+
+}

--- a/src/main/java/com/example/homeaid/manager/entity/ManagerAvailability.java
+++ b/src/main/java/com/example/homeaid/manager/entity/ManagerAvailability.java
@@ -9,16 +9,14 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
+import java.time.LocalTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
-@Builder
 @Entity
 @Table(name = "manager_availability")
 public class ManagerAvailability {
@@ -27,14 +25,25 @@ public class ManagerAvailability {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  @Setter
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "manager_id")
   private Manager manager;
 
   private LocalDate availableDate;
 
-  private LocalDateTime availableTime;
+  private LocalTime startTime;
+  private LocalTime endTime;
 
   private String region;
+
+  @Builder
+  public ManagerAvailability(LocalDate availableDate, LocalTime startTime, LocalTime endTime,
+      String region) {
+    this.availableDate = availableDate;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.region = region;
+  }
 
 }

--- a/src/main/java/com/example/homeaid/manager/entity/ManagerAvailability.java
+++ b/src/main/java/com/example/homeaid/manager/entity/ManagerAvailability.java
@@ -1,0 +1,32 @@
+package com.example.homeaid.manager.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "manager_availability")
+public class ManagerAvailability {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "manager_id")
+  private Manager manager;
+
+  private LocalDate availableDate;
+
+  private LocalDateTime availableTime;
+
+  private String region;
+
+}

--- a/src/main/java/com/example/homeaid/manager/entity/enumerated/GenderType.java
+++ b/src/main/java/com/example/homeaid/manager/entity/enumerated/GenderType.java
@@ -1,5 +1,0 @@
-package com.example.homeaid.manager.entity.enumerated;
-
-public enum GenderType {
-  MAIL, FEMALE;
-}

--- a/src/main/java/com/example/homeaid/manager/entity/enumerated/GenderType.java
+++ b/src/main/java/com/example/homeaid/manager/entity/enumerated/GenderType.java
@@ -1,0 +1,5 @@
+package com.example.homeaid.manager.entity.enumerated;
+
+public enum GenderType {
+  MAIL, FEMALE;
+}


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- User를 상속받는 구조의 Customer 및 Manager 엔티티를 설계하였고, 역할별 개별 프로필 정보를 분리하여 도메인 역할을 명확히 했습니다.
- Manager의 활동 가능 시간(지역/날짜/시간대)과 Customer의 주소 리스트를 별도 테이블로 분리하고, 연관관계를 설정하였습니다.
- 엔티티 설계 시 불필요한 Lombok 어노테이션 사용을 최소화하고, 연관관계 편의 메서드도 일부 도입하였습니다.

---

## ✏️ 변경 사항
- `User` 엔티티 설계 및 `JOINED` 상속 전략 적용
  - 공통 필드(email, password, name, phone, gender, role 등)
- `Customer`, `Manager` 엔티티 설계
  - `Customer`: 다중 주소 등록 기능을 위한 `CustomerAddress`와 1:N 관계 설정
  - `Manager`: 경력, 경험, 프로필 이미지, 첨부 서류 URL, 승인 상태 등 고유 필드 정의
- `ManagerAvailability` 엔티티 생성
  - 활동 가능 날짜(LocalDate), 지역(String), 시간 범위(startTime, endTime: LocalTime) 관리
  - `Manager`와 1:N 관계 설정 및 `cascade + orphanRemoval` 적용
- 연관관계 편의 메서드 추가
  - `addAvailability()` / `addAddress()` 등 양방향 관계 주입 보조
- 승인 처리 도메인 메서드 추가
  - `approve()` 메서드를 통해 `verified` 상태 및 시간 설정
- 불필요한 `@Setter`, `@AllArgsConstructor` 제거, 생성자 기반 `@Builder` 패턴 적용

---

## 📎 기타 참고 사항
- 파일 첨부(PDF)는 외부 스토리지 연동을 고려하여 `documentUrl`로만 저장
- 상속 구조에서 `@Builder` 사용 시 `super(...)`를 통한 필드 전달 방식 적용


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #16 