### PR TITLE
RDS DB로 변환

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,11 @@ pipeline {
     environment {
         DISCORD_WEBHOOK = credentials('discord-webhook')
         DB_DRIVER = 'mysql'
-        DB_HOST = 'mysql-ci'
+        DB_HOST = 'homeaid-db.c98ykwkigxsn.ap-northeast-2.rds.amazonaws.com'
         DB_PORT = '3306'
         DB_NAME = 'homeaid_db'
-        DB_USERNAME = 'homeaid_user'
-        DB_PASSWORD = 'root'
+        DB_USERNAME = credentials('rds-db-credentials').username
+        DB_PASSWORD = credentials('rds-db-credentials').password
     }
 
     tools {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,11 @@ pipeline {
     environment {
         DISCORD_WEBHOOK = credentials('discord-webhook')
         DB_DRIVER = 'mysql'
-        DB_HOST = 'homeaid-db.c98ykwkigxsn.ap-northeast-2.rds.amazonaws.com'
+        DB_HOST = 'mysql-ci'
         DB_PORT = '3306'
         DB_NAME = 'homeaid_db'
+        DB_USERNAME = 'homeaid_user'
+        DB_PASSWORD = 'root'
     }
 
     tools {
@@ -34,11 +36,6 @@ pipeline {
         stage('Build and Test') {
             steps {
                 sh 'chmod +x ./gradlew'
-                withCredentials([usernamePassword(
-                    credentialsId: 'rds-db',
-                    usernameVariable: 'DB_USERNAME',
-                    passwordVariable: 'DB_PASSWORD'
-                )]) {
                 withEnv([
                     "DB_DRIVER=${DB_DRIVER}",
                     "DB_HOST=${DB_HOST}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,6 @@ pipeline {
         DB_HOST = 'homeaid-db.c98ykwkigxsn.ap-northeast-2.rds.amazonaws.com'
         DB_PORT = '3306'
         DB_NAME = 'homeaid_db'
-        DB_USERNAME = credentials('rds-db-credentials').username
-        DB_PASSWORD = credentials('rds-db-credentials').password
     }
 
     tools {
@@ -36,6 +34,11 @@ pipeline {
         stage('Build and Test') {
             steps {
                 sh 'chmod +x ./gradlew'
+                withCredentials([usernamePassword(
+                    credentialsId: 'rds-db',
+                    usernameVariable: 'DB_USERNAME',
+                    passwordVariable: 'DB_PASSWORD'
+                )]) {
                 withEnv([
                     "DB_DRIVER=${DB_DRIVER}",
                     "DB_HOST=${DB_HOST}",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,24 +12,6 @@ services:
     networks:
       - ci-network
 
-  mysql-ci:
-    image: mysql:latest
-    container_name: mysql-ci
-    ports:
-      - "3306:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: homeaid_db
-      MYSQL_USER: homeaid_user
-      MYSQL_PASSWORD: root
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-    networks:
-      - ci-network
-
 volumes:
   jenkins_home:
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- Jenkins CI/CD 파이프라인에서 사용 중이던 Docker Compose의 mysql-ci 컨테이너를 제거하고, AWS RDS(MySQL)로 DB를 전환하기 위한 PR입니다.
- DB 연결 정보가 Jenkinsfile, application.yml 등에서 RDS로 연결되도록 설정 변경했습니다.


## ✏️ 변경 사항
- Jenkinsfile의 DB_HOST를 RDS 엔드포인트로 변경
- docker-compose.yml에서 mysql-ci 서비스 제거
- RDS 접속 테스트 완료 후 Jenkins 빌드 연동 설정
- Gradle 애플리케이션 설정(application.yml)에서 RDS 설정 적용
- Jenkins Credentials에 RDS 접속 정보 등록 및 적용

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
#80 