### PR TITLE
API test 버그 수정 및 예약, 매칭 로그인 검증 추가

### DIFF
--- a/global/src/main/java/com/homeaid/config/SwaggerConfig.java
+++ b/global/src/main/java/com/homeaid/config/SwaggerConfig.java
@@ -58,17 +58,15 @@ public class SwaggerConfig {
   }
 
   @Bean
-
   public GroupedOpenApi matchingAPI() {
     return GroupedOpenApi.builder()
         .group("matchings")
         .displayName("매칭")
-        .pathsToMatch("/api/v1/admin/matchings/**")
+        .pathsToMatch("/api/v1/*/matchings/**")
         .build();
   }
       
   @Bean
-
   public GroupedOpenApi userAPI() {
 
     return GroupedOpenApi.builder()
@@ -79,7 +77,6 @@ public class SwaggerConfig {
   }
 
   @Bean
-
   public GroupedOpenApi worklogAPI() {
     return GroupedOpenApi.builder()
             .group("workLogs")

--- a/global/src/main/java/com/homeaid/exception/GlobalExceptionHandler.java
+++ b/global/src/main/java/com/homeaid/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -29,7 +31,8 @@ public class GlobalExceptionHandler {
    */
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<CommonApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
-    String message = e.getBindingResult().getFieldErrors().stream()
+    // FieldError와 ObjectError 모두 수집
+    String message = e.getBindingResult().getAllErrors().stream()
         .findFirst()
         .map(DefaultMessageSourceResolvable::getDefaultMessage)
         .orElse("입력값이 올바르지 않습니다.");
@@ -61,6 +64,5 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest()
             .body(CommonApiResponse.fail("duplicate value", "이미 처리된 요청 입니다"));
   }
-
 
 }

--- a/global/src/main/java/com/homeaid/exception/GlobalExceptionHandler.java
+++ b/global/src/main/java/com/homeaid/exception/GlobalExceptionHandler.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.validation.FieldError;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/reservation/src/main/java/com/homeaid/controller/MatchingController.java
+++ b/reservation/src/main/java/com/homeaid/controller/MatchingController.java
@@ -26,14 +26,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/admin/matchings")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @Tag(name = "Admin Matching", description = "관리자 매칭 관리 API")
 public class MatchingController {
 
   private final MatchingService matchingService;
 
-  @PostMapping
+  @PostMapping("/admin/matchings")
   @Operation(summary = "매칭 생성", description = "관리자가 예약과 매니저 정보를 기반으로 매칭을 생성합니다.")
   public ResponseEntity<CommonApiResponse<Long>> createMatching(
       @Valid @RequestBody CreateMatchingRequestDto matchingRequestDto) {
@@ -44,7 +44,7 @@ public class MatchingController {
         .body(CommonApiResponse.success(matchingId));
   }
 
-  @PatchMapping("/{matchingId}/to-customer")
+  @PatchMapping("/manager/matchings/{matchingId}/to-customer")
   @Operation(summary = "매니저 매칭 응답", description = "매니저가 수락 또는 거절로 매칭에 응답합니다.")
   public ResponseEntity<CommonApiResponse<Void>> respondToMatching(
       @Parameter(description = "매칭 ID", required = true)
@@ -57,7 +57,7 @@ public class MatchingController {
     return ResponseEntity.ok().body(CommonApiResponse.success());
   }
 
-  @PatchMapping("/{matchingId}/to-manager")
+  @PatchMapping("/customer/matchings/{matchingId}/to-manager")
   @Operation(summary = "고객 매칭 응답", description = "고객이 수락 또는 거절로 매칭에 응답합니다.")
   public ResponseEntity<CommonApiResponse<Void>> respondToMatching(
       @Parameter(description = "매칭 ID", required = true)
@@ -70,7 +70,7 @@ public class MatchingController {
     return ResponseEntity.ok().body(CommonApiResponse.success());
   }
 
-  @PostMapping("/{reservationId}/recommendations")
+  @PostMapping("/admin/matchings/{reservationId}/recommendations")
   @Operation(summary = "예약 기반 매니저 추천", description = "예약 정보를 기반으로 가능한 매니저 10명을 추천합니다.")
   @ApiResponse(responseCode = "200", description = "매니저 추천 성공",
       content = @Content(schema = @Schema(implementation = MatchingRecommendationResponseDto.class)))

--- a/reservation/src/main/java/com/homeaid/controller/MatchingController.java
+++ b/reservation/src/main/java/com/homeaid/controller/MatchingController.java
@@ -6,6 +6,7 @@ import com.homeaid.dto.request.MatchingCustomerResponseDto;
 import com.homeaid.dto.request.MatchingManagerResponseDto;
 import com.homeaid.dto.response.MatchingRecommendationResponseDto;
 import com.homeaid.dto.response.ReservationResponseDto;
+import com.homeaid.security.CustomUserDetails;
 import com.homeaid.service.MatchingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +19,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -47,11 +49,12 @@ public class MatchingController {
   @PatchMapping("/manager/matchings/{matchingId}/to-customer")
   @Operation(summary = "매니저 매칭 응답", description = "매니저가 수락 또는 거절로 매칭에 응답합니다.")
   public ResponseEntity<CommonApiResponse<Void>> respondToMatching(
+      @AuthenticationPrincipal CustomUserDetails user,
       @Parameter(description = "매칭 ID", required = true)
       @PathVariable(name = "matchingId") Long matchingId,
       @RequestBody @Valid MatchingManagerResponseDto requestDto
   ) {
-    matchingService.respondToMatchingAsManager(matchingId, requestDto.getAction(),
+    matchingService.respondToMatchingAsManager(user.getUserId(), matchingId, requestDto.getAction(),
         requestDto.getMemo());
 
     return ResponseEntity.ok().body(CommonApiResponse.success());
@@ -60,11 +63,13 @@ public class MatchingController {
   @PatchMapping("/customer/matchings/{matchingId}/to-manager")
   @Operation(summary = "고객 매칭 응답", description = "고객이 수락 또는 거절로 매칭에 응답합니다.")
   public ResponseEntity<CommonApiResponse<Void>> respondToMatching(
+      @AuthenticationPrincipal CustomUserDetails user,
       @Parameter(description = "매칭 ID", required = true)
       @PathVariable(name = "matchingId") Long matchingId,
       @RequestBody @Valid MatchingCustomerResponseDto requestDto
   ) {
-    matchingService.respondToMatchingAsCustomer(matchingId, requestDto.getAction(),
+
+    matchingService.respondToMatchingAsCustomer(user.getUserId(), matchingId, requestDto.getAction(),
         requestDto.getMemo());
 
     return ResponseEntity.ok().body(CommonApiResponse.success());

--- a/reservation/src/main/java/com/homeaid/domain/Reservation.java
+++ b/reservation/src/main/java/com/homeaid/domain/Reservation.java
@@ -84,7 +84,8 @@ public class Reservation {
     item.setReservation(this);
   }
 
-  public void updateReservation(Reservation newReservation, int newTotalPrice, int newTotalDuration) {
+  public void updateReservation(Reservation newReservation, int newTotalPrice,
+      int newTotalDuration) {
     this.requestedDate = newReservation.getRequestedDate();
     this.requestedTime = newReservation.getRequestedTime();
     this.totalPrice = newTotalPrice;
@@ -103,7 +104,13 @@ public class Reservation {
     this.status = ReservationStatus.COMPLETED;
   }
   
+
+  public void updateStatusMatching() {
+    this.status = ReservationStatus.MATCHING;
+  }
+
   public void confirmMatching(Long matchingId) {
+    this.status = ReservationStatus.MATCHED;
     finalMatchingId = matchingId;
 
   }

--- a/reservation/src/main/java/com/homeaid/domain/Reservation.java
+++ b/reservation/src/main/java/com/homeaid/domain/Reservation.java
@@ -59,7 +59,8 @@ public class Reservation {
   @Column(columnDefinition = "TEXT")
   private String customerMemo;
 
-  @OneToOne(mappedBy = "reservation", cascade = CascadeType.ALL)
+  // 부모 엔티티 저장이나 병합하면 자식 엔티티도 자동으로 저장이나 병합 됨.
+  @OneToOne(mappedBy = "reservation", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   private ReservationItem item;
 
   @CreatedDate
@@ -92,6 +93,9 @@ public class Reservation {
 
   public void softDelete() {
     this.deletedDate = LocalDateTime.now();
+    if (this.item != null) {
+      this.item.softDelete();
+    }
   }
 
 

--- a/reservation/src/main/java/com/homeaid/domain/ReservationItem.java
+++ b/reservation/src/main/java/com/homeaid/domain/ReservationItem.java
@@ -2,19 +2,26 @@ package com.homeaid.domain;
 
 
 import com.homeaid.serviceoption.domain.ServiceSubOption;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class ReservationItem {
 
   @Id
@@ -31,6 +38,15 @@ public class ReservationItem {
   @OneToOne(fetch = FetchType.LAZY)
   private Reservation reservation;
 
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdDate;
+
+  @LastModifiedDate
+  private LocalDateTime modifiedDate;
+
+  private LocalDateTime deletedDate;
+
   public ReservationItem(ServiceSubOption serviceSubOption) {
     this.subOptionName = serviceSubOption.getName();
     this.basePrice = serviceSubOption.getBasePrice();
@@ -41,6 +57,10 @@ public class ReservationItem {
     this.subOptionName = subOption.getName();
     this.basePrice = subOption.getBasePrice();
     this.duration = subOption.getDurationMinutes();
+  }
+
+  public void softDelete() {
+    this.deletedDate = LocalDateTime.now();
   }
 
 

--- a/reservation/src/main/java/com/homeaid/dto/request/MatchingCustomerResponseDto.java
+++ b/reservation/src/main/java/com/homeaid/dto/request/MatchingCustomerResponseDto.java
@@ -1,5 +1,7 @@
 package com.homeaid.dto.request;
 
+import com.homeaid.validation.MatchingActionMemoRequest;
+import com.homeaid.validation.MatchingMemoConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -8,7 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Schema(description = "고객 매칭 응답 DTO")
-public class MatchingCustomerResponseDto {
+@MatchingMemoConstraint
+public class MatchingCustomerResponseDto implements MatchingActionMemoRequest {
 
   @NotNull
   @Schema(description = "고객의 응답 액션", example = "CONFIRM")
@@ -22,4 +25,5 @@ public class MatchingCustomerResponseDto {
     CONFIRM,
     REJECT
   }
+
 }

--- a/reservation/src/main/java/com/homeaid/dto/request/MatchingManagerResponseDto.java
+++ b/reservation/src/main/java/com/homeaid/dto/request/MatchingManagerResponseDto.java
@@ -1,5 +1,7 @@
 package com.homeaid.dto.request;
 
+import com.homeaid.validation.MatchingActionMemoRequest;
+import com.homeaid.validation.MatchingMemoConstraint;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -8,7 +10,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Schema(description = "매니저 매칭 응답 DTO")
-public class MatchingManagerResponseDto {
+@MatchingMemoConstraint
+public class MatchingManagerResponseDto implements MatchingActionMemoRequest {
 
   @NotNull
   @Schema(description = "매니저의 응답 액션", example = "ACCEPT")
@@ -22,4 +25,5 @@ public class MatchingManagerResponseDto {
     ACCEPT,
     REJECT
   }
+
 }

--- a/reservation/src/main/java/com/homeaid/dto/request/ReservationRequestDto.java
+++ b/reservation/src/main/java/com/homeaid/dto/request/ReservationRequestDto.java
@@ -17,10 +17,6 @@ import lombok.NoArgsConstructor;
 public class ReservationRequestDto {
 
   @NotNull
-  @Schema(description = "예약을 요청하는 고객의 ID", example = "1")
-  private Long customerId;
-
-  @NotNull
   @Schema(description = "예약 요청 날짜 (yyyy-MM-dd)", example = "2025-06-10")
   private LocalDate requestedDate;
 
@@ -32,14 +28,19 @@ public class ReservationRequestDto {
   @Schema(description = "선택한 서비스 하위 옵션 ID", example = "3")
   private Long subOptionId;
 
-  public static Reservation toEntity(ReservationRequestDto reservationRequestDto) {
-
+  public static Reservation toEntity(ReservationRequestDto reservationRequestDto, Long userId) {
     return Reservation.builder()
-        .customerId(reservationRequestDto.getCustomerId())
+        .customerId(userId)
         .requestedDate(reservationRequestDto.getRequestedDate())
         .requestedTime(reservationRequestDto.getRequestedTime())
         .build();
+  }
 
+  public static Reservation toEntity(ReservationRequestDto reservationRequestDto) {
+    return Reservation.builder()
+        .requestedDate(reservationRequestDto.getRequestedDate())
+        .requestedTime(reservationRequestDto.getRequestedTime())
+        .build();
   }
 
 }

--- a/reservation/src/main/java/com/homeaid/exception/ReservationErrorCode.java
+++ b/reservation/src/main/java/com/homeaid/exception/ReservationErrorCode.java
@@ -12,6 +12,9 @@ public enum ReservationErrorCode implements BaseErrorCode {
   INVALID_RESERVATION_TIME(HttpStatus.BAD_REQUEST, "INVALID_RESERVATION_TIME", "예약 시간이 올바르지 않습니다."),
   INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "INVALID_RESERVATION_STATUS", "현재 상태에서는 예약을 수정할 수 없습니다."),
 
+  // 403 FORBIDDEN
+  UNAUTHORIZED_RESERVATION_ACCESS(HttpStatus.FORBIDDEN, "UNAUTHORIZED_RESERVATION_ACCESS", "예약에 대한 접근 권한이 없습니다."),
+
   // 404 NOT FOUND
   RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION_NOT_FOUND", "예약을 찾을 수 없습니다."),
   SERVICE_OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SERVICE_OPTION_NOT_FOUND", "선택한 서비스 옵션을 찾을 수 없습니다."),

--- a/reservation/src/main/java/com/homeaid/service/MatchingService.java
+++ b/reservation/src/main/java/com/homeaid/service/MatchingService.java
@@ -12,9 +12,9 @@ public interface MatchingService {
 
   Long createMatching(Long managerId, Long reservationId, Matching matching);
 
-  void respondToMatchingAsManager(Long matchingId, ManagerAction action, String memo);
+  void respondToMatchingAsManager(Long userId, Long matchingId, ManagerAction action, String memo);
 
-  void respondToMatchingAsCustomer(Long matchingId, CustomerAction action, String memo);
+  void respondToMatchingAsCustomer(Long userId, Long matchingId, CustomerAction action, String memo);
 
   List<Manager> recommendManagers(Long reservationId);
 }

--- a/reservation/src/main/java/com/homeaid/service/MatchingServiceImpl.java
+++ b/reservation/src/main/java/com/homeaid/service/MatchingServiceImpl.java
@@ -44,6 +44,8 @@ public class MatchingServiceImpl implements MatchingService {
     matching.setReservationAndManagerAndMatchingRound(reservation, manager,
         calculateNextMatchingRound(reservationId));
 
+    reservation.updateStatusMatching();
+    
     return matchingRepository.save(matching).getId();
   }
 

--- a/reservation/src/main/java/com/homeaid/service/ReservationService.java
+++ b/reservation/src/main/java/com/homeaid/service/ReservationService.java
@@ -8,9 +8,9 @@ public interface ReservationService {
 
   Reservation createReservation(Reservation reservation, Long serviceSubOptionId);
 
-  Reservation getReservation(Long id);
+  Reservation getReservation(Long reservationId);
 
-  Reservation updateReservation(Long id, Reservation reservation, Long serviceSubOptionId);
+  Reservation updateReservation(Long reservationId, Long userId, Reservation reservation, Long serviceSubOptionId);
 
-  void deleteReservation(Long id);
+  void deleteReservation(Long reservationId, Long userId);
 }

--- a/reservation/src/main/java/com/homeaid/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/com/homeaid/service/ReservationServiceImpl.java
@@ -39,10 +39,14 @@ public class ReservationServiceImpl implements ReservationService {
 
   @Override
   @Transactional
-  public Reservation updateReservation(Long id, Reservation newReservation,
+  public Reservation updateReservation(Long reservationId, Long userId, Reservation newReservation,
       Long serviceSubOptionId) {
-    Reservation originReservation = reservationRepository.findById(id)
+    Reservation originReservation = reservationRepository.findById(reservationId)
         .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+    if (!originReservation.getCustomerId().equals(userId)) {
+      throw new CustomException(ReservationErrorCode.RESERVATION_CANNOT_UPDATE)  ;
+    }
 
     if (originReservation.getStatus() != ReservationStatus.REQUESTED) {
       throw new CustomException(ReservationErrorCode.RESERVATION_CANNOT_UPDATE);
@@ -63,9 +67,14 @@ public class ReservationServiceImpl implements ReservationService {
 
   @Override
   @Transactional
-  public void deleteReservation(Long id) {
-    Reservation reservation = reservationRepository.findById(id)
+  public void deleteReservation(Long reservationId, Long userId) {
+
+    Reservation reservation = reservationRepository.findById(reservationId)
         .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+    if (!reservation.getCustomerId().equals(userId)) {
+      throw new CustomException(ReservationErrorCode.RESERVATION_CANNOT_UPDATE)  ;
+    }
 
     reservation.softDelete();
   }

--- a/reservation/src/main/java/com/homeaid/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/com/homeaid/service/ReservationServiceImpl.java
@@ -45,7 +45,7 @@ public class ReservationServiceImpl implements ReservationService {
         .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
     if (!originReservation.getCustomerId().equals(userId)) {
-      throw new CustomException(ReservationErrorCode.RESERVATION_CANNOT_UPDATE)  ;
+      throw new CustomException(ReservationErrorCode.UNAUTHORIZED_RESERVATION_ACCESS)  ;
     }
 
     if (originReservation.getStatus() != ReservationStatus.REQUESTED) {
@@ -73,7 +73,7 @@ public class ReservationServiceImpl implements ReservationService {
         .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
 
     if (!reservation.getCustomerId().equals(userId)) {
-      throw new CustomException(ReservationErrorCode.RESERVATION_CANNOT_UPDATE)  ;
+      throw new CustomException(ReservationErrorCode.UNAUTHORIZED_RESERVATION_ACCESS)  ;
     }
 
     reservation.softDelete();

--- a/reservation/src/main/java/com/homeaid/validation/MatchingActionMemoRequest.java
+++ b/reservation/src/main/java/com/homeaid/validation/MatchingActionMemoRequest.java
@@ -1,0 +1,6 @@
+package com.homeaid.validation;
+
+public interface MatchingActionMemoRequest {
+  Enum<?> getAction();
+  String getMemo();
+}

--- a/reservation/src/main/java/com/homeaid/validation/MatchingMemoConstraint.java
+++ b/reservation/src/main/java/com/homeaid/validation/MatchingMemoConstraint.java
@@ -1,0 +1,19 @@
+package com.homeaid.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = MatchingMemoValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MatchingMemoConstraint {
+  String message() default "거절(REJECT)일 경우 memo는 필수이며, 수락(ACCEPT)일 경우 memo는 없어야 합니다.";
+  Class<?>[] groups() default {};
+  Class<? extends Payload>[] payload() default {};
+}

--- a/reservation/src/main/java/com/homeaid/validation/MatchingMemoValidator.java
+++ b/reservation/src/main/java/com/homeaid/validation/MatchingMemoValidator.java
@@ -1,0 +1,24 @@
+package com.homeaid.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class MatchingMemoValidator implements ConstraintValidator<MatchingMemoConstraint, MatchingActionMemoRequest> {
+
+  @Override
+  public boolean isValid(MatchingActionMemoRequest dto, ConstraintValidatorContext context) {
+    if (dto.getAction() == null) {
+      return true;
+    }
+
+    String actionName = dto.getAction().name();
+
+    if ("REJECT".equals(actionName)) {
+      return dto.getMemo() != null && !dto.getMemo().trim().isEmpty();
+    } else if ("ACCEPT".equals(actionName) || "CONFIRM".equals(actionName)) {
+      return dto.getMemo() == null || dto.getMemo().trim().isEmpty();
+    }
+
+    return true;
+  }
+}

--- a/reservation/src/test/java/com/homeaid/service/MatchingServiceTest.java
+++ b/reservation/src/test/java/com/homeaid/service/MatchingServiceTest.java
@@ -185,10 +185,11 @@ class MatchingServiceTest {
     // given
     Long matchingId = 1L;
     given(matchingRepository.findById(matchingId)).willReturn(Optional.empty());
+    Long userId = 1L;
 
     // when & then
     assertThatThrownBy(() ->
-        matchingService.respondToMatchingAsManager(matchingId, ManagerAction.ACCEPT, null)
+        matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.ACCEPT, null)
     ).isInstanceOf(CustomException.class)
         .hasMessageContaining("매칭 정보를 찾을 수 없습니다.");
   }
@@ -200,9 +201,10 @@ class MatchingServiceTest {
     Long matchingId = 1L;
     Matching matching = mock(Matching.class);
     given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
+    Long userId = 1L;
 
     // when
-    matchingService.respondToMatchingAsManager(matchingId, ManagerAction.ACCEPT, null);
+    matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.ACCEPT, null);
 
     // then
     verify(matching).acceptByManager();
@@ -215,11 +217,12 @@ class MatchingServiceTest {
     // given
     Long matchingId = 1L;
     Matching matching = mock(Matching.class);
+    Long userId = 1L;
     given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
 
     // when & then
     assertThatThrownBy(() ->
-        matchingService.respondToMatchingAsManager(matchingId, ManagerAction.REJECT, null)
+        matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.REJECT, null)
     ).isInstanceOf(CustomException.class)
         .hasMessageContaining("거절 시에는 메모를 작성해야 합니다.");
   }
@@ -231,10 +234,11 @@ class MatchingServiceTest {
     Long matchingId = 1L;
     String memo = "사정이 있어 수락이 어렵습니다.";
     Matching matching = mock(Matching.class);
+    Long userId = 1L;
     given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
 
     // when
-    matchingService.respondToMatchingAsManager(matchingId, ManagerAction.REJECT, memo);
+    matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.REJECT, memo);
 
     // then
     verify(matching).rejectByManager(memo);

--- a/reservation/src/test/java/com/homeaid/service/MatchingServiceTest.java
+++ b/reservation/src/test/java/com/homeaid/service/MatchingServiceTest.java
@@ -199,9 +199,14 @@ class MatchingServiceTest {
   void respondToMatchingAsManager_수락시_acceptByManager_호출() {
     // given
     Long matchingId = 1L;
-    Matching matching = mock(Matching.class);
-    given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
     Long userId = 1L;
+
+    Matching matching = mock(Matching.class);
+    Manager manager = mock(Manager.class);
+
+    given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
+    given(matching.getManager()).willReturn(manager);
+    given(manager.getId()).willReturn(userId);
 
     // when
     matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.ACCEPT, null);
@@ -216,14 +221,20 @@ class MatchingServiceTest {
   void respondToMatchingAsManager_거절시_memo가_없으면_예외_발생() {
     // given
     Long matchingId = 1L;
-    Matching matching = mock(Matching.class);
     Long userId = 1L;
+
+    Matching matching = mock(Matching.class);
+    Manager manager = mock(Manager.class);
+
     given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
+    given(matching.getManager()).willReturn(manager);
+    given(manager.getId()).willReturn(userId);
 
     // when & then
     assertThatThrownBy(() ->
         matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.REJECT, null)
-    ).isInstanceOf(CustomException.class)
+    )
+        .isInstanceOf(CustomException.class)
         .hasMessageContaining("거절 시에는 메모를 작성해야 합니다.");
   }
 
@@ -233,9 +244,14 @@ class MatchingServiceTest {
     // given
     Long matchingId = 1L;
     String memo = "사정이 있어 수락이 어렵습니다.";
-    Matching matching = mock(Matching.class);
     Long userId = 1L;
+
+    Matching matching = mock(Matching.class);
+    Manager manager = mock(Manager.class);
+
     given(matchingRepository.findById(matchingId)).willReturn(Optional.of(matching));
+    given(matching.getManager()).willReturn(manager);
+    given(manager.getId()).willReturn(userId);
 
     // when
     matchingService.respondToMatchingAsManager(userId, matchingId, ManagerAction.REJECT, memo);


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 예약이 soft delete될 때 예약 아이템(ReservationItem)도 같이 soft delete되도록 로직 추가.
- 매칭 응답 시(ACCEPT) 메모가 작성되지 않도록 DTO 검증 로직 추가.
- ReservationStatus 상태 전환 로직을 재검토 및 수정하여 상태 관리의 일관성을 강화.

## ✏️ 변경 사항
- ReservationItem에 soft delete(deletedDate) 필드 추가 및 soft delete 메서드 구현.
- Reservation soft delete 시 ReservationItem도 같이 soft delete되도록 코드 수정.
- Reservation.softDelete()에서 ReservationItem.softDelete() 호출 추가.
- MatchingManagerResponseDto 및 MatchingCustomerResponseDto에 커스텀 유효성 검증(@MatchingMemoConstraint) 적용.
- ACCEPT일 때 메모 작성 방지, REJECT일 때 메모 필수 작성.
- MatchingMemoValidator 구현:
    - 공통 인터페이스(MatchingActionMemoRequest) 도입 → Manager/Customer DTO에서 재사용 가능.
- MethodArgumentNotValidException 핸들러 수정: 
    - FieldError뿐 아니라 ObjectError까지 모두 처리해 유효성 검증 메시지를 클라이언트에 반환.
- ReservationStatus 관련 상태 관리 로직 점검 및 개선.
- 예약 상태 흐름 재점검 및 필요한 부분 리팩토링(예: status 값 체크 및 변경 시점 보완).


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
#86 