### PR TITLE
[Refactor] 매니저 서류 제출 기능 리팩토링 및 수정 기능 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %cyan(%logger{36}) - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/user/src/main/java/com/homeaid/controller/CustomerController.java
+++ b/user/src/main/java/com/homeaid/controller/CustomerController.java
@@ -2,8 +2,8 @@ package com.homeaid.controller;
 
 import com.homeaid.common.response.CommonApiResponse;
 import com.homeaid.domain.CustomerAddress;
-import com.homeaid.dto.request.CustomerAddressUpdateRequestDto;
 import com.homeaid.dto.request.CustomerAddressSaveRequestDto;
+import com.homeaid.dto.request.CustomerAddressUpdateRequestDto;
 import com.homeaid.dto.response.CustomerAddressResponseDto;
 import com.homeaid.security.user.CustomUserDetails;
 import com.homeaid.service.CustomerAddressService;
@@ -20,7 +20,14 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Customer Controller", description = "고객 API")
 @RestController

--- a/user/src/main/java/com/homeaid/controller/ManagerController.java
+++ b/user/src/main/java/com/homeaid/controller/ManagerController.java
@@ -71,7 +71,6 @@ public class ManagerController {
     }
 
     Long managerId = user.getUserId();
-
     managerService.uploadManagerFiles(managerId, idFile, criminalRecordFile, healthCertificateFile);
 
     return ResponseEntity.status(HttpStatus.CREATED)

--- a/user/src/main/java/com/homeaid/controller/ManagerController.java
+++ b/user/src/main/java/com/homeaid/controller/ManagerController.java
@@ -21,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -30,7 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Manager Controller", description = "매니저 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/managers/profile")
+@RequestMapping("/api/v1/manager/profile")
 public class ManagerController {
 
   private final ManagerService managerService;
@@ -94,10 +95,31 @@ public class ManagerController {
 
     Long managerId = user.getUserId();
 
-    Manager manager = managerService.getUploadManagerFiles(managerId);
+    Manager manager = managerService.getManagerFiles(managerId);
     ManagerDocumentListResponseDto documentsList = ManagerDocumentListResponseDto.toDto(manager);
 
     return ResponseEntity.status(HttpStatus.OK)
         .body(CommonApiResponse.success(documentsList));
+  }
+
+  @Operation(
+      summary = "매니저 신분 및 자격 증빙서류 수정",
+      description = "매니저의 신분 및 자격을 증빙하기 위한 기존 서류를 수정합니다. (신분증, 범죄경력조회서, 건강검진서)"
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "증빙서류 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "수정할 파일이 비어있음"),
+      @ApiResponse(responseCode = "404", description = "매니저를 찾을 수 없음")
+  })
+  @PutMapping(value = "/certifications", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<CommonApiResponse<Void>> updateCertifications(
+      @RequestPart(required = false) MultipartFile idFile,
+      @RequestPart(required = false) MultipartFile criminalRecordFile,
+      @RequestPart(required = false) MultipartFile healthCertificateFile,
+      @AuthenticationPrincipal CustomUserDetails user
+  ) throws IOException {
+      Long managerId = user.getUserId();
+      managerService.updateManagerFiles(managerId, idFile, criminalRecordFile, healthCertificateFile);
+      return ResponseEntity.ok(CommonApiResponse.success(null));
   }
 }

--- a/user/src/main/java/com/homeaid/controller/ManagerController.java
+++ b/user/src/main/java/com/homeaid/controller/ManagerController.java
@@ -60,7 +60,7 @@ public class ManagerController {
       @ApiResponse(responseCode = "404", description = "매니저를 찾을 수 없음")
   })
   @PostMapping(value = "/certifications", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<CommonApiResponse<Void>> uploadCertifications(
+  public ResponseEntity<CommonApiResponse<ManagerDocumentListResponseDto>> uploadCertifications(
       @RequestPart MultipartFile idFile,
       @RequestPart MultipartFile criminalRecordFile,
       @RequestPart MultipartFile healthCertificateFile,
@@ -72,10 +72,11 @@ public class ManagerController {
     }
 
     Long managerId = user.getUserId();
-    managerService.uploadManagerFiles(managerId, idFile, criminalRecordFile, healthCertificateFile);
+    Manager manager = managerService.uploadManagerFiles(managerId, idFile, criminalRecordFile,
+        healthCertificateFile);
+    ManagerDocumentListResponseDto documentsList = ManagerDocumentListResponseDto.toDto(manager);
 
-    return ResponseEntity.status(HttpStatus.CREATED)
-        .body(CommonApiResponse.success(null));
+    return ResponseEntity.status(HttpStatus.CREATED).body(CommonApiResponse.success(documentsList));
   }
 
 
@@ -112,14 +113,17 @@ public class ManagerController {
       @ApiResponse(responseCode = "404", description = "매니저를 찾을 수 없음")
   })
   @PutMapping(value = "/certifications", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  public ResponseEntity<CommonApiResponse<Void>> updateCertifications(
+  public ResponseEntity<CommonApiResponse<ManagerDocumentListResponseDto>> updateCertifications(
       @RequestPart(required = false) MultipartFile idFile,
       @RequestPart(required = false) MultipartFile criminalRecordFile,
       @RequestPart(required = false) MultipartFile healthCertificateFile,
       @AuthenticationPrincipal CustomUserDetails user
   ) throws IOException {
-      Long managerId = user.getUserId();
-      managerService.updateManagerFiles(managerId, idFile, criminalRecordFile, healthCertificateFile);
-      return ResponseEntity.ok(CommonApiResponse.success(null));
+    Long managerId = user.getUserId();
+    Manager manager = managerService.updateManagerFiles(managerId, idFile, criminalRecordFile, healthCertificateFile);
+    ManagerDocumentListResponseDto documentsList = ManagerDocumentListResponseDto.toDto(manager);
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(CommonApiResponse.success(documentsList));
   }
 }

--- a/user/src/main/java/com/homeaid/domain/ManagerDocument.java
+++ b/user/src/main/java/com/homeaid/domain/ManagerDocument.java
@@ -44,11 +44,11 @@ public class ManagerDocument {
   @Column(name = "document_url")
   private String documentUrl; // 신분증, 범죄 경력 조회서, 보건증 및 건강검진서
 
-  @Column(name = "file_size", nullable = false)
-  private Long fileSize;
-
   @Column(name = "file_extention", nullable = false)
   private String fileExtension;
+
+  @Column(name = "file_size", nullable = false)
+  private Long fileSize;
 
   @CreatedDate
   private LocalDateTime createdAt;
@@ -58,14 +58,14 @@ public class ManagerDocument {
   private Manager manager;
 
   @Builder
-  public ManagerDocument(DocumentType documentType, String originalName, String documentS3Key, String documentUrl, Long fileSize, String fileExtension,
+  public ManagerDocument(DocumentType documentType, String originalName, String documentS3Key, String documentUrl,String fileExtension, Long fileSize,
       Manager manager) {
     this.documentType = documentType;
     this.originalName = originalName;
     this.documentS3Key = documentS3Key;
     this.documentUrl = documentUrl;
-    this.fileSize = fileSize;
     this.fileExtension = fileExtension;
+    this.fileSize = fileSize;
     this.manager = manager;
   }
 }

--- a/user/src/main/java/com/homeaid/domain/ManagerDocument.java
+++ b/user/src/main/java/com/homeaid/domain/ManagerDocument.java
@@ -38,13 +38,13 @@ public class ManagerDocument {
   @Column(name = "original_name", nullable = false)
   private String originalName;
 
-  @Column(name = "document_s3_key")
-  private String documentS3Key;
+  @Column(name = "s3_key")
+  private String s3Key;
 
-  @Column(name = "document_url")
-  private String documentUrl; // 신분증, 범죄 경력 조회서, 보건증 및 건강검진서
+  @Column(name = "url")
+  private String url; // 신분증, 범죄 경력 조회서, 보건증 및 건강검진서
 
-  @Column(name = "file_extention", nullable = false)
+  @Column(name = "file_extension", nullable = false)
   private String fileExtension;
 
   @Column(name = "file_size", nullable = false)
@@ -58,12 +58,12 @@ public class ManagerDocument {
   private Manager manager;
 
   @Builder
-  public ManagerDocument(DocumentType documentType, String originalName, String documentS3Key, String documentUrl,String fileExtension, Long fileSize,
+  public ManagerDocument(DocumentType documentType, String originalName, String s3Key, String url,String fileExtension, Long fileSize,
       Manager manager) {
     this.documentType = documentType;
     this.originalName = originalName;
-    this.documentS3Key = documentS3Key;
-    this.documentUrl = documentUrl;
+    this.s3Key = s3Key;
+    this.url = url;
     this.fileExtension = fileExtension;
     this.fileSize = fileSize;
     this.manager = manager;

--- a/user/src/main/java/com/homeaid/domain/ManagerDocument.java
+++ b/user/src/main/java/com/homeaid/domain/ManagerDocument.java
@@ -35,25 +35,37 @@ public class ManagerDocument {
   @Column(name = "document_type")
   private DocumentType documentType;
 
+  @Column(name = "original_name", nullable = false)
+  private String originalName;
+
   @Column(name = "document_s3_key")
   private String documentS3Key;
 
   @Column(name = "document_url")
   private String documentUrl; // 신분증, 범죄 경력 조회서, 보건증 및 건강검진서
 
+  @Column(name = "file_size", nullable = false)
+  private Long fileSize;
+
+  @Column(name = "file_extention", nullable = false)
+  private String fileExtension;
+
   @CreatedDate
-  private LocalDateTime uploadedAt;
+  private LocalDateTime createdAt;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "manager_id")
   private Manager manager;
 
   @Builder
-  public ManagerDocument(DocumentType documentType, String documentS3Key, String documentUrl,
+  public ManagerDocument(DocumentType documentType, String originalName, String documentS3Key, String documentUrl, Long fileSize, String fileExtension,
       Manager manager) {
     this.documentType = documentType;
+    this.originalName = originalName;
     this.documentS3Key = documentS3Key;
     this.documentUrl = documentUrl;
+    this.fileSize = fileSize;
+    this.fileExtension = fileExtension;
     this.manager = manager;
   }
 }

--- a/user/src/main/java/com/homeaid/domain/ManagerDocument.java
+++ b/user/src/main/java/com/homeaid/domain/ManagerDocument.java
@@ -58,7 +58,8 @@ public class ManagerDocument {
   private Manager manager;
 
   @Builder
-  public ManagerDocument(DocumentType documentType, String originalName, String s3Key, String url,String fileExtension, Long fileSize,
+  public ManagerDocument(DocumentType documentType, String originalName, String s3Key, String url,
+      String fileExtension, Long fileSize,
       Manager manager) {
     this.documentType = documentType;
     this.originalName = originalName;

--- a/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
+++ b/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
@@ -19,7 +19,7 @@ public record ManagerDocumentDto(
         document.getId(),
         document.getDocumentType(),
         document.getOriginalName(),
-        document.getDocumentUrl(),
+        document.getUrl(),
         document.getFileExtension(),
         formattedSize,
         document.getCreatedAt()

--- a/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
+++ b/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
@@ -5,15 +5,24 @@ import com.homeaid.domain.ManagerDocument;
 import java.time.LocalDateTime;
 
 public record ManagerDocumentDto(
+    Long id,
     DocumentType documentType,
+    String originalName,
     String documentUrl,
-    LocalDateTime uploadedAt
+    String fileExtension,
+    String fileSize,
+    LocalDateTime createdAt
 ) {
   public static ManagerDocumentDto toDto(ManagerDocument document) {
+    String formattedSize = String.format("%.2f MB", document.getFileSize() / 1024.0 / 1024.0);
     return new ManagerDocumentDto(
+        document.getId(),
         document.getDocumentType(),
+        document.getOriginalName(),
         document.getDocumentUrl(),
-        document.getUploadedAt()
+        document.getFileExtension(),
+        formattedSize,
+        document.getCreatedAt()
     );
   }
 }

--- a/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
+++ b/user/src/main/java/com/homeaid/dto/response/ManagerDocumentDto.java
@@ -13,6 +13,7 @@ public record ManagerDocumentDto(
     String fileSize,
     LocalDateTime createdAt
 ) {
+
   public static ManagerDocumentDto toDto(ManagerDocument document) {
     String formattedSize = String.format("%.2f MB", document.getFileSize() / 1024.0 / 1024.0);
     return new ManagerDocumentDto(

--- a/user/src/main/java/com/homeaid/dto/response/ManagerDocumentListResponseDto.java
+++ b/user/src/main/java/com/homeaid/dto/response/ManagerDocumentListResponseDto.java
@@ -5,14 +5,15 @@ import com.homeaid.domain.enumerate.ManagerStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-public record ManagerDocumentListResponseDto (
+public record ManagerDocumentListResponseDto(
     @Schema(description = "매니저 활동 승인 상태", example = "PENDING")
     ManagerStatus status,
 
     @Schema(description = "매니저 첨부 서류")
     List<ManagerDocumentDto> documentList
 
-){
+) {
+
   public static ManagerDocumentListResponseDto toDto(Manager manager) {
     return new ManagerDocumentListResponseDto(
         manager.getStatus(),

--- a/user/src/main/java/com/homeaid/repository/ManagerDocumentRepository.java
+++ b/user/src/main/java/com/homeaid/repository/ManagerDocumentRepository.java
@@ -1,8 +1,11 @@
 package com.homeaid.repository;
 
 import com.homeaid.domain.ManagerDocument;
+import com.homeaid.common.enumerate.DocumentType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ManagerDocumentRepository extends JpaRepository<ManagerDocument, Long> {
+import java.util.Optional;
 
+public interface ManagerDocumentRepository extends JpaRepository<ManagerDocument, Long> {
+    Optional<ManagerDocument> findByManagerIdAndDocumentType(Long managerId, DocumentType documentType);
 }

--- a/user/src/main/java/com/homeaid/repository/ManagerDocumentRepository.java
+++ b/user/src/main/java/com/homeaid/repository/ManagerDocumentRepository.java
@@ -1,11 +1,12 @@
 package com.homeaid.repository;
 
-import com.homeaid.domain.ManagerDocument;
 import com.homeaid.common.enumerate.DocumentType;
+import com.homeaid.domain.ManagerDocument;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ManagerDocumentRepository extends JpaRepository<ManagerDocument, Long> {
-    Optional<ManagerDocument> findByManagerIdAndDocumentType(Long managerId, DocumentType documentType);
+
+  Optional<ManagerDocument> findByManagerIdAndDocumentType(Long managerId,
+      DocumentType documentType);
 }

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentService.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentService.java
@@ -6,7 +6,9 @@ import com.homeaid.domain.ManagerDocument;
 import java.util.List;
 
 public interface ManagerDocumentService {
+
   List<ManagerDocument> upload(Manager manager, List<UploadFileParam> files);
+
   List<ManagerDocument> update(Manager manager, List<UploadFileParam> files);
 }
 

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentService.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentService.java
@@ -1,0 +1,12 @@
+package com.homeaid.service;
+
+import com.homeaid.common.request.UploadFileParam;
+import com.homeaid.domain.Manager;
+import com.homeaid.domain.ManagerDocument;
+import java.util.List;
+
+public interface ManagerDocumentService {
+  List<ManagerDocument> upload(Manager manager, List<UploadFileParam> files);
+  List<ManagerDocument> update(Manager manager, List<UploadFileParam> files);
+}
+

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
@@ -78,8 +78,8 @@ public class ManagerDocumentServiceImpl implements ManagerDocumentService {
 
 
   // 파일 확장자 추출
-  private String getFileExtension(String filename) {
-    if (filename == null || !filename.contains(".")) return "";
-    return filename.substring(filename.lastIndexOf(".") + 1);
+  private String getFileExtension(String originalFilename) {
+    if (originalFilename == null || !originalFilename.contains(".")) return "";
+    return originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
   }
 }

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
@@ -26,7 +26,8 @@ public class ManagerDocumentServiceImpl implements ManagerDocumentService {
         .filter(param -> param.file() != null && !param.file().isEmpty())
         .map(param -> {
           try {
-            FileUploadResult result = s3Service.uploadFile(param.documentType(), param.packageName(), param.file());
+            FileUploadResult result = s3Service.uploadFile(param.documentType(),
+                param.packageName(), param.file());
 
             return ManagerDocument.builder()
                 .documentType(param.documentType())
@@ -50,14 +51,16 @@ public class ManagerDocumentServiceImpl implements ManagerDocumentService {
     return files.stream()
         .filter(param -> param.file() != null && !param.file().isEmpty())
         .map(param -> {
-          managerDocumentRepository.findByManagerIdAndDocumentType(manager.getId(), param.documentType())
+          managerDocumentRepository.findByManagerIdAndDocumentType(manager.getId(),
+                  param.documentType())
               .ifPresent(existing -> {
                 s3Service.deleteFile(existing.getS3Key());
                 managerDocumentRepository.delete(existing);
               });
 
           try {
-            FileUploadResult result = s3Service.uploadFile(param.documentType(), param.packageName(), param.file());
+            FileUploadResult result = s3Service.uploadFile(param.documentType(),
+                param.packageName(), param.file());
 
             return ManagerDocument.builder()
                 .documentType(param.documentType())
@@ -79,7 +82,9 @@ public class ManagerDocumentServiceImpl implements ManagerDocumentService {
 
   // 파일 확장자 추출
   private String getFileExtension(String originalFilename) {
-    if (originalFilename == null || !originalFilename.contains(".")) return "";
+    if (originalFilename == null || !originalFilename.contains(".")) {
+      return "";
+    }
     return originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
   }
 }

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
@@ -1,0 +1,85 @@
+package com.homeaid.service;
+
+import com.homeaid.common.request.UploadFileParam;
+import com.homeaid.common.response.FileUploadResult;
+import com.homeaid.domain.Manager;
+import com.homeaid.domain.ManagerDocument;
+import com.homeaid.exception.CustomException;
+import com.homeaid.exception.ErrorCode;
+import com.homeaid.repository.ManagerDocumentRepository;
+import com.homeaid.util.S3Service;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerDocumentServiceImpl implements ManagerDocumentService {
+
+  private final ManagerDocumentRepository managerDocumentRepository;
+  private final S3Service s3Service;
+
+  @Override
+  public List<ManagerDocument> upload(Manager manager, List<UploadFileParam> files) {
+    return files.stream()
+        .filter(param -> param.file() != null && !param.file().isEmpty())
+        .map(param -> {
+          try {
+            FileUploadResult result = s3Service.uploadFile(param.documentType(), param.packageName(), param.file());
+
+            return ManagerDocument.builder()
+                .documentType(param.documentType())
+                .originalName(param.file().getOriginalFilename())
+                .fileExtension(getFileExtension(param.file().getOriginalFilename()))
+                .fileSize(param.file().getSize())
+                .s3Key(result.getS3Key())
+                .url(result.getUrl())
+                .manager(manager)
+                .build();
+
+          } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+          }
+        })
+        .toList();
+  }
+
+  @Override
+  public List<ManagerDocument> update(Manager manager, List<UploadFileParam> files) {
+    return files.stream()
+        .filter(param -> param.file() != null && !param.file().isEmpty())
+        .map(param -> {
+          managerDocumentRepository.findByManagerIdAndDocumentType(manager.getId(), param.documentType())
+              .ifPresent(existing -> {
+                s3Service.deleteFile(existing.getS3Key());
+                managerDocumentRepository.delete(existing);
+              });
+
+          try {
+            FileUploadResult result = s3Service.uploadFile(param.documentType(), param.packageName(), param.file());
+
+            return ManagerDocument.builder()
+                .documentType(param.documentType())
+                .originalName(param.file().getOriginalFilename())
+                .fileExtension(getFileExtension(param.file().getOriginalFilename()))
+                .fileSize(param.file().getSize())
+                .s3Key(result.getS3Key())
+                .url(result.getUrl())
+                .manager(manager)
+                .build();
+
+          } catch (IOException e) {
+            throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+          }
+        })
+        .toList();
+  }
+
+
+  // 파일 확장자 추출
+  private String getFileExtension(String filename) {
+    if (filename == null || !filename.contains(".")) return "";
+    return filename.substring(filename.lastIndexOf(".") + 1);
+  }
+}

--- a/user/src/main/java/com/homeaid/service/ManagerService.java
+++ b/user/src/main/java/com/homeaid/service/ManagerService.java
@@ -1,10 +1,8 @@
 package com.homeaid.service;
 
 import com.homeaid.domain.Manager;
-import com.homeaid.domain.ManagerDocument;
 import com.homeaid.dto.request.ManagerDetailInfoRequestDto;
 import java.io.IOException;
-import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ManagerService {
@@ -15,7 +13,8 @@ public interface ManagerService {
       MultipartFile healthFile)
       throws IOException;
 
-  Manager getUploadManagerFiles(Long managerId);
-
+  Manager getManagerFiles(Long managerId);
+  void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile, MultipartFile healthFile)
+      throws IOException;
   Manager getManagerById(Long id);
 }

--- a/user/src/main/java/com/homeaid/service/ManagerService.java
+++ b/user/src/main/java/com/homeaid/service/ManagerService.java
@@ -14,7 +14,10 @@ public interface ManagerService {
       throws IOException;
 
   Manager getManagerFiles(Long managerId);
-  void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile, MultipartFile healthFile)
+
+  void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+      MultipartFile healthFile)
       throws IOException;
+
   Manager getManagerById(Long id);
 }

--- a/user/src/main/java/com/homeaid/service/ManagerService.java
+++ b/user/src/main/java/com/homeaid/service/ManagerService.java
@@ -9,13 +9,13 @@ public interface ManagerService {
 
   void saveManagerDetailInfo(Long managerId, ManagerDetailInfoRequestDto requestDto);
 
-  void uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+  Manager uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
       MultipartFile healthFile)
       throws IOException;
 
   Manager getManagerFiles(Long managerId);
 
-  void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+  Manager updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
       MultipartFile healthFile)
       throws IOException;
 

--- a/user/src/main/java/com/homeaid/service/ManagerServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerServiceImpl.java
@@ -2,7 +2,6 @@ package com.homeaid.service;
 
 import com.homeaid.common.enumerate.DocumentType;
 import com.homeaid.common.request.UploadFileParam;
-import com.homeaid.common.response.FileUploadResult;
 import com.homeaid.domain.Manager;
 import com.homeaid.domain.ManagerAvailability;
 import com.homeaid.domain.ManagerDocument;
@@ -11,19 +10,16 @@ import com.homeaid.domain.ManagerServiceOption;
 import com.homeaid.domain.enumerate.Weekday;
 import com.homeaid.dto.request.ManagerDetailInfoRequestDto;
 import com.homeaid.exception.CustomException;
-import com.homeaid.exception.ErrorCode;
 import com.homeaid.exception.UserErrorCode;
 import com.homeaid.repository.ManagerAvailabilityRepository;
 import com.homeaid.repository.ManagerDocumentRepository;
 import com.homeaid.repository.ManagerRepository;
 import com.homeaid.repository.ManagerServiceOptionRepository;
-import com.homeaid.util.S3Service;
-import java.io.IOException;
 import com.homeaid.util.RegionValidator;
+import java.io.IOException;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -58,7 +54,6 @@ public class ManagerServiceImpl implements ManagerService {
             .build())
         .collect(Collectors.toList());
     managerServiceOptionRepository.saveAll(preferences);
-
 
     // 2. 가능한 요일 조건 및 선호 지역 저장
     List<ManagerAvailability> availabilities = dto.getAvailabilities().stream()
@@ -103,7 +98,8 @@ public class ManagerServiceImpl implements ManagerService {
   }
 
   @Override
-  public void uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile, MultipartFile healthFile)
+  public void uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+      MultipartFile healthFile)
       throws IOException {
 
     Manager manager = getManagerById(managerId);
@@ -119,14 +115,15 @@ public class ManagerServiceImpl implements ManagerService {
   }
 
   @Override
-  public void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile, MultipartFile healthFile) throws IOException {
+  public void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+      MultipartFile healthFile) throws IOException {
     Manager manager = getManagerById(managerId);
 
     List<UploadFileParam> fileParams = List.of(
-        new UploadFileParam(DocumentType.ID_CARD, S3_PACKAGE_NAME_ID, idFile),
-        new UploadFileParam(DocumentType.CRIMINAL_RECORD, S3_PACKAGE_NAME_CRIMINAL, criminalFile),
-        new UploadFileParam(DocumentType.HEALTH_CERTIFICATE, S3_PACKAGE_NAME_HEALTH, healthFile)
-    ).stream()
+            new UploadFileParam(DocumentType.ID_CARD, S3_PACKAGE_NAME_ID, idFile),
+            new UploadFileParam(DocumentType.CRIMINAL_RECORD, S3_PACKAGE_NAME_CRIMINAL, criminalFile),
+            new UploadFileParam(DocumentType.HEALTH_CERTIFICATE, S3_PACKAGE_NAME_HEALTH, healthFile)
+        ).stream()
         .filter(param -> param.file() != null && !param.file().isEmpty())
         .toList();
 
@@ -173,5 +170,5 @@ public class ManagerServiceImpl implements ManagerService {
     return managerRepository.findById(id)
         .orElseThrow(() -> new CustomException(UserErrorCode.MANAGER_NOT_FOUND));
   }
-  
+
 }

--- a/user/src/main/java/com/homeaid/service/ManagerServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerServiceImpl.java
@@ -98,7 +98,7 @@ public class ManagerServiceImpl implements ManagerService {
   }
 
   @Override
-  public void uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+  public Manager uploadManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
       MultipartFile healthFile)
       throws IOException {
 
@@ -112,10 +112,12 @@ public class ManagerServiceImpl implements ManagerService {
 
     List<ManagerDocument> documents = managerDocumentService.upload(manager, fileParams);
     managerDocumentRepository.saveAll(documents);
+
+    return manager;
   }
 
   @Override
-  public void updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
+  public Manager updateManagerFiles(Long managerId, MultipartFile idFile, MultipartFile criminalFile,
       MultipartFile healthFile) throws IOException {
     Manager manager = getManagerById(managerId);
 
@@ -128,11 +130,13 @@ public class ManagerServiceImpl implements ManagerService {
         .toList();
 
     if (fileParams.isEmpty()) {
-      return;
+      return manager;
     }
 
     List<ManagerDocument> updatedDocuments = managerDocumentService.update(manager, fileParams);
     managerDocumentRepository.saveAll(updatedDocuments);
+
+    return manager;
   }
 
   @Override

--- a/worklog/src/main/java/com/homeaid/service/WorkLogServiceImpl.java
+++ b/worklog/src/main/java/com/homeaid/service/WorkLogServiceImpl.java
@@ -25,7 +25,7 @@ public class WorkLogServiceImpl implements WorkLogService {
 
   private final WorkLogRepository workLogRepository;
   private final ReservationRepository reservationRepository;
-  private final static int CHECK_RANGE_DISTANCE_METER = 500; //500미터
+  private final static int CHECK_RANGE_DISTANCE_METER = 1000; //500미터
   private final MatchingRepository matchingRepository;
 
   @Transactional
@@ -75,6 +75,7 @@ public class WorkLogServiceImpl implements WorkLogService {
    * @return 예약 위치와 체크인 위치의 차이가 CHECK_RANGE_DISTANCE_METER 범위 안에 있으면 true
    */
   private boolean isValidDistance(Long reservationId, Double latitude, Double longitude) {
+    System.out.println(latitude + "+TTHhH+H+h+===" + longitude);
     Reservation reservation = reservationRepository.findById(reservationId)
         .orElseThrow(() -> new CustomException(ReservationErrorCode.RESERVATION_NOT_FOUND));
     double calculatedDistance = GeoUtils.calculateDistanceInMeters(reservation.getLatitude(),


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매니저가 제출한 서류(신분증, 범죄경력조회서, 건강검진서)를 선택적으로 수정할 수 있도록 기능을 추가하였습니다.
- 업로드 및 수정 시 파일의 메타데이터(파일 이름, 확장자, 크기)를 DB에 저장하고 응답으로 내려줍니다.
- 파일 수정 시 기존 파일은 S3 및 DB에서 삭제되며, 새 파일로 교체됩니다.

## ✏️ 변경 사항
- ManagerDocumentServiceImpl에 `upload`, `update` 기능 분리 및 확장
- 파일 업로드 시 확장자, 파일 크기 저장 로직 추가
- ManagerServiceImpl 내 서류 제출/수정 로직 리팩토링
- 기존 문서 삭제 및 새로운 문서 저장 시 정합성 유지
- 불필요한 Setter 제거 및 엔티티 생성 책임 명확화

## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #155 