### PR TITLE
[Feature] #165 매니저 서류 파일 다운로드 기능 추가

### DIFF
--- a/admin/src/main/java/com/homeaid/user/controller/AdminManagerController.java
+++ b/admin/src/main/java/com/homeaid/user/controller/AdminManagerController.java
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -124,16 +123,16 @@ public class AdminManagerController {
   // ResponseEntity<byte[]>로 바로 전달해야 브라우저가 파일로 인식 가능
   @GetMapping("/{documentId}/download")
   public ResponseEntity<byte[]> downloadDocument(@PathVariable Long documentId) {
-      ManagerDocument doc = documentRepository.findById(documentId)
-          .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+    ManagerDocument doc = documentRepository.findById(documentId)
+        .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
 
-      var file = s3Service.downloadFile(doc.getS3Key());
+    var file = s3Service.downloadFile(doc.getS3Key());
 
-      return ResponseEntity.ok()
-          .contentType(org.springframework.http.MediaType.parseMediaType(file.getContentType()))
-          .contentLength(file.getContentLength())
-          .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION,
-              "attachment; filename=\"" + doc.getOriginalName() + "\"")
-          .body(file.getContent());
+    return ResponseEntity.ok()
+        .contentType(org.springframework.http.MediaType.parseMediaType(file.getContentType()))
+        .contentLength(file.getContentLength())
+        .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION,
+            "attachment; filename=\"" + doc.getOriginalName() + "\"")
+        .body(file.getContent());
   }
 }

--- a/admin/src/main/java/com/homeaid/user/controller/AdminManagerController.java
+++ b/admin/src/main/java/com/homeaid/user/controller/AdminManagerController.java
@@ -3,18 +3,24 @@ package com.homeaid.user.controller;
 import com.homeaid.common.response.CommonApiResponse;
 import com.homeaid.common.response.PagedResponseDto;
 import com.homeaid.domain.Manager;
+import com.homeaid.domain.ManagerDocument;
 import com.homeaid.dto.request.StatusChangeRequest;
 import com.homeaid.dto.response.ManagerDocumentListResponseDto;
 import com.homeaid.dto.response.ManagerResponseDto;
+import com.homeaid.exception.CustomException;
+import com.homeaid.exception.ErrorCode;
+import com.homeaid.repository.ManagerDocumentRepository;
 import com.homeaid.user.dto.request.AdminDocumentReviewRequest;
 import com.homeaid.user.dto.request.AdminManagerSearchRequestDto;
 import com.homeaid.user.service.AdminManagerService;
+import com.homeaid.util.S3Service;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.net.URL;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +45,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminManagerController {
 
   private final AdminManagerService adminManagerService;
+  private final S3Service s3Service;
+  private final ManagerDocumentRepository documentRepository;
+
 
   @GetMapping
   @Operation(summary = "매니저 목록 조회 (검색 포함)", description = "이름, 전화번호, 경력, 상태로 매니저를 검색합니다.")
@@ -109,5 +118,22 @@ public class AdminManagerController {
       @PathVariable Long managerId) {
     ManagerDocumentListResponseDto dto = adminManagerService.getManagerDocuments(managerId);
     return ResponseEntity.ok(CommonApiResponse.success(dto));
+  }
+
+  // 파일 다운로드
+  // ResponseEntity<byte[]>로 바로 전달해야 브라우저가 파일로 인식 가능
+  @GetMapping("/{documentId}/download")
+  public ResponseEntity<byte[]> downloadDocument(@PathVariable Long documentId) {
+      ManagerDocument doc = documentRepository.findById(documentId)
+          .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+      var file = s3Service.downloadFile(doc.getS3Key());
+
+      return ResponseEntity.ok()
+          .contentType(org.springframework.http.MediaType.parseMediaType(file.getContentType()))
+          .contentLength(file.getContentLength())
+          .header(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION,
+              "attachment; filename=\"" + doc.getOriginalName() + "\"")
+          .body(file.getContent());
   }
 }

--- a/global/src/main/java/com/homeaid/common/response/FileDownloadResult.java
+++ b/global/src/main/java/com/homeaid/common/response/FileDownloadResult.java
@@ -1,0 +1,19 @@
+package com.homeaid.common.response;
+
+import java.util.Date;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FileDownloadResult {
+
+  private byte[] content;           // 파일 바이너리
+  private String originalFileName;  // 파일 원본 이름
+  private String contentType;       // MIME 타입 (ex. image/jpeg, application/pdf 등)
+  private long contentLength;       // 바이트 단위 크기
+  private String fileExtension;     // 파일 확장자
+  private Date lastModified;        // 마지막 수정일자
+  private String s3Key;             // S3 파일 키
+
+}

--- a/global/src/main/java/com/homeaid/config/SwaggerConfig.java
+++ b/global/src/main/java/com/homeaid/config/SwaggerConfig.java
@@ -124,7 +124,7 @@ public class SwaggerConfig {
   public GroupedOpenApi managerAPI() {
     return GroupedOpenApi.builder()
         .group("매니저")
-        .pathsToMatch("/api/v1/managers/**")
+        .pathsToMatch("/api/v1/managers/**", "/api/v1/manager/profile/**")
         .build();
   }
 

--- a/global/src/main/java/com/homeaid/exception/ErrorCode.java
+++ b/global/src/main/java/com/homeaid/exception/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode implements BaseErrorCode {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR",
       "서버 오류가 발생했습니다."),
   FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_UPLOAD_ERROR", "파일 업로드 중 에러가 발생했습니다."),
-  FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DELETE_ERROR", "파일 삭제 중 에러가 발생했습니다.");
+  FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DELETE_ERROR", "파일 삭제 중 에러가 발생했습니다."),
+  FILE_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DOWNLOAD_ERROR", "파일 다운로드 중 에러가 발생했습니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/global/src/main/java/com/homeaid/exception/ErrorCode.java
+++ b/global/src/main/java/com/homeaid/exception/ErrorCode.java
@@ -25,6 +25,8 @@ public enum ErrorCode implements BaseErrorCode {
 
   // 404 NOT FOUND
   RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
+  FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "FILE_TOO_LARGE", "파일 크기가 허용된 최대 크기를 초과했습니다."),
+  FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_NOT_FOUND", "파일을 찾을 수 없습니다."),
 
   // 405 METHOD NOT ALLOWED
   METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "허용되지 않은 HTTP 메서드입니다."),
@@ -38,6 +40,7 @@ public enum ErrorCode implements BaseErrorCode {
   FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_UPLOAD_ERROR", "파일 업로드 중 에러가 발생했습니다."),
   FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DELETE_ERROR", "파일 삭제 중 에러가 발생했습니다."),
   FILE_DOWNLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_DOWNLOAD_ERROR", "파일 다운로드 중 에러가 발생했습니다.");
+
 
   private final HttpStatus status;
   private final String code;

--- a/global/src/main/java/com/homeaid/util/S3Service.java
+++ b/global/src/main/java/com/homeaid/util/S3Service.java
@@ -76,20 +76,22 @@ public class S3Service {
 
   // 파일 다운로드
   public byte[] getFile(String fileKey) throws FileNotFoundException {
+    log.debug("파일 다운로드 시작 - key: {}", fileKey);
 
     // S3 파일 유무 확인
     validateFileExists(fileKey);
 
-    S3Object s3Object = amazonS3.getObject(bucket, fileKey);
-    S3ObjectInputStream s3ObjectContent = s3Object.getObjectContent();
+    try (S3Object s3Object = amazonS3.getObject(bucket, fileKey);
+        S3ObjectInputStream s3ObjectContent = s3Object.getObjectContent()){
 
-    try {
-      log.debug("파일 다운로드 - key: {}", fileKey);
-      return IOUtils.toByteArray(s3ObjectContent);
+      byte[] content = IOUtils.toByteArray(s3ObjectContent);
+      log.debug("파일 다운로드 - key: {}, size: {} bytes", fileKey, content.length);
+
+      return content;
 
     } catch (IOException e) {
       log.error("파일 다운로드 실패 - key: {}", fileKey, e);
-      throw new FileNotFoundException();
+      throw new CustomException(ErrorCode.FILE_DOWNLOAD_ERROR);
     }
   }
 

--- a/reservation/src/main/java/com/homeaid/controller/ServiceIssueController.java
+++ b/reservation/src/main/java/com/homeaid/controller/ServiceIssueController.java
@@ -8,6 +8,7 @@ import com.homeaid.security.user.CustomUserDetails;
 import com.homeaid.service.ServiceIssueService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.FileNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -80,7 +81,7 @@ public class ServiceIssueController {
   @Operation(summary = "서비스 이슈 삭제", description = "매니저가 서비스 이슈를 삭제합니다.")
   public ResponseEntity<CommonApiResponse<Void>> deleteIssue(
       @PathVariable("issueId") Long issueId,
-      @AuthenticationPrincipal CustomUserDetails user) {
+      @AuthenticationPrincipal CustomUserDetails user) throws FileNotFoundException {
 
     serviceIssueService.deleteIssue(issueId, user.getUserId());
 

--- a/reservation/src/main/java/com/homeaid/service/ServiceIssueFileService.java
+++ b/reservation/src/main/java/com/homeaid/service/ServiceIssueFileService.java
@@ -1,6 +1,7 @@
 package com.homeaid.service;
 
 import com.homeaid.domain.ServiceIssue;
+import java.io.FileNotFoundException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -10,6 +11,6 @@ public interface ServiceIssueFileService {
 
   void updateFiles(ServiceIssue serviceIssue, List<MultipartFile> files, List<Long> deleteImageIds);
 
-  void deleteFiles(ServiceIssue serviceIssue);
+  void deleteFiles(ServiceIssue serviceIssue) throws FileNotFoundException;
 
 }

--- a/reservation/src/main/java/com/homeaid/service/ServiceIssueService.java
+++ b/reservation/src/main/java/com/homeaid/service/ServiceIssueService.java
@@ -1,6 +1,7 @@
 package com.homeaid.service;
 
 import com.homeaid.domain.ServiceIssue;
+import java.io.FileNotFoundException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,5 +14,5 @@ public interface ServiceIssueService {
   ServiceIssue updateIssue(Long issueId, Long managerId, String content, List<MultipartFile> files,
       List<Long> deleteImageIds);
 
-  void deleteIssue(Long issueId, Long managerId);
+  void deleteIssue(Long issueId, Long managerId) throws FileNotFoundException;
 }

--- a/reservation/src/main/java/com/homeaid/service/ServiceIssueServiceImpl.java
+++ b/reservation/src/main/java/com/homeaid/service/ServiceIssueServiceImpl.java
@@ -5,6 +5,7 @@ import com.homeaid.domain.ServiceIssue;
 import com.homeaid.exception.CustomException;
 import com.homeaid.exception.ServiceIssueErrorCode;
 import com.homeaid.repository.ServiceIssueRepository;
+import java.io.FileNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -69,7 +70,7 @@ public class ServiceIssueServiceImpl implements ServiceIssueService {
 
   @Override
   @Transactional
-  public void deleteIssue(Long issueId, Long managerId) {
+  public void deleteIssue(Long issueId, Long managerId) throws FileNotFoundException {
 
     ServiceIssue issue = findIssueById(issueId);
     findIssueByIdAndManagerAccess(issueId, managerId);

--- a/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
+++ b/user/src/main/java/com/homeaid/service/ManagerDocumentServiceImpl.java
@@ -8,6 +8,7 @@ import com.homeaid.exception.CustomException;
 import com.homeaid.exception.ErrorCode;
 import com.homeaid.repository.ManagerDocumentRepository;
 import com.homeaid.util.S3Service;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -54,7 +55,11 @@ public class ManagerDocumentServiceImpl implements ManagerDocumentService {
           managerDocumentRepository.findByManagerIdAndDocumentType(manager.getId(),
                   param.documentType())
               .ifPresent(existing -> {
-                s3Service.deleteFile(existing.getS3Key());
+                try {
+                  s3Service.deleteFile(existing.getS3Key());
+                } catch (FileNotFoundException e) {
+                  throw new CustomException(ErrorCode.FILE_DELETE_ERROR);
+                }
                 managerDocumentRepository.delete(existing);
               });
 


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 매니저가 제출한 문서를 관리자가 다운로드할 수 있도록
  S3에 저장된 파일을 직접 byte[]로 반환하는 다운로드 API를 구현하였습니다.

## ✏️ 변경 사항
- `AdminManagerController`에 다운로드 API 추가
  - GET /api/v1/admin/managers/{documentId}/download
- `S3Service.downloadFile()` 구현 
  - S3에서 byte[] 다운로드 및 Content-Type 반환
- `ErrorCode.FILE_NOT_FOUND` 등 파일 관련 예외 대응 포함

## 📸 스크린샷 (선택사항)
(해당 사항 없음)

## ✅ 체크리스트
- [x] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [x] 테스트를 통과했나요? (Swagger / Postman 수동 테스트 포함)
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #164 