### PR TITLE
[Refactor] 관리자 통계 일 단위 확장 및 구조리팩토링, 대시보드 수정

### DIFF
--- a/admin/src/main/java/com/homeaid/dashboard/controller/AdminDashboardController.java
+++ b/admin/src/main/java/com/homeaid/dashboard/controller/AdminDashboardController.java
@@ -2,7 +2,9 @@ package com.homeaid.dashboard.controller;
 
 import com.homeaid.common.response.CommonApiResponse;
 import com.homeaid.dashboard.dto.AdminDashboardStatsDto;
+import com.homeaid.dashboard.dto.DailyRevenueRefundDto;
 import com.homeaid.dashboard.service.AdminDashboardService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/admin/src/main/java/com/homeaid/dashboard/dto/AdminDashboardStatsDto.java
+++ b/admin/src/main/java/com/homeaid/dashboard/dto/AdminDashboardStatsDto.java
@@ -10,11 +10,19 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class AdminDashboardStatsDto {
-  private long totalUsers;
-  private long activeManagers;
-  private long totalPayments;
-  private long todayReservations;
-  private long totalPaymentAmount;
-  private long totalSettlementAmount;
-  private long pendingApprovals;
+
+  // 매출 현황
+  private long todayRevenue;
+  private long weeklyRevenue;
+  private long monthlyRevenue;
+  private long netRevenue;
+
+  // 환불 정보
+  private long totalRefundAmount;
+  private double refundRate; // (%)
+
+  // 수익 분석
+  private long platformProfit;
+  private long managerSettlementAmount;
+
 }

--- a/admin/src/main/java/com/homeaid/dashboard/dto/AdminDashboardStatsDto.java
+++ b/admin/src/main/java/com/homeaid/dashboard/dto/AdminDashboardStatsDto.java
@@ -1,5 +1,6 @@
 package com.homeaid.dashboard.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class AdminDashboardStatsDto {
   private long todayRevenue;
   private long weeklyRevenue;
   private long monthlyRevenue;
+  private long totalPayments;
   private long netRevenue;
 
   // 환불 정보
@@ -24,5 +26,9 @@ public class AdminDashboardStatsDto {
   // 수익 분석
   private long platformProfit;
   private long managerSettlementAmount;
+  private double profitRate; // 플랫폼 수익률 (%)
+
+  // 일별 매출/환불 추이 (그래프용)
+  private List<DailyRevenueRefundDto> dailyStats;
 
 }

--- a/admin/src/main/java/com/homeaid/dashboard/dto/DailyRevenueRefundDto.java
+++ b/admin/src/main/java/com/homeaid/dashboard/dto/DailyRevenueRefundDto.java
@@ -1,0 +1,14 @@
+package com.homeaid.dashboard.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DailyRevenueRefundDto {
+  private String date; // 예: "2025-07-10"
+  private long paymentAmount;
+  private long refundAmount;
+}

--- a/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardService.java
+++ b/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardService.java
@@ -1,7 +1,10 @@
 package com.homeaid.dashboard.service;
 
 import com.homeaid.dashboard.dto.AdminDashboardStatsDto;
+import com.homeaid.dashboard.dto.DailyRevenueRefundDto;
+import java.util.List;
 
 public interface AdminDashboardService {
   AdminDashboardStatsDto getStats();
+  List<DailyRevenueRefundDto> getLast7DaysRevenueAndRefundStats();
 }

--- a/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardServiceImpl.java
@@ -2,6 +2,7 @@ package com.homeaid.dashboard.service;
 
 
 import com.homeaid.dashboard.dto.AdminDashboardStatsDto;
+import com.homeaid.dashboard.dto.DailyRevenueRefundDto;
 import com.homeaid.payment.repository.PaymentRepository;
 import com.homeaid.payment.repository.RefundRepository;
 import com.homeaid.repository.ManagerRepository;
@@ -10,6 +11,8 @@ import com.homeaid.repository.UserRepository;
 import com.homeaid.settlement.repository.SettlementRepository;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class AdminDashboardServiceImpl implements AdminDashboardService {
 
   private final PaymentRepository paymentRepository;
+  private final RefundRepository refundRepository;
 
   @Override
   public AdminDashboardStatsDto getStats() {
@@ -26,13 +30,11 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
     int month = today.getMonthValue();
     int day = today.getDayOfMonth();
 
-    // 오늘 매출
+    // 매출
     long todayRevenue = paymentRepository.sumPayments(year, month, day);
-
-    // 이번 달 매출
     long monthlyRevenue = paymentRepository.sumPayments(year, month, null);
 
-    // 이번 주 매출 (월요일 ~ 오늘)
+    // 주간 매출
     LocalDate monday = today.with(DayOfWeek.MONDAY);
     long weeklyRevenue = 0;
     for (LocalDate date = monday; !date.isAfter(today); date = date.plusDays(1)) {
@@ -40,32 +42,61 @@ public class AdminDashboardServiceImpl implements AdminDashboardService {
           date.getYear(), date.getMonthValue(), date.getDayOfMonth());
     }
 
-    // 전체 결제액
+    // 전체 결제/환불
     long totalPayments = paymentRepository.sumAllPaymentAmounts();
-
-    // 전체 환불 금액
     long totalRefundAmount = paymentRepository.sumCanceledPayments(year, null, null);
 
-    // 순매출 = 전체 결제 - 환불
+    // 순매출, 수익
     long netRevenue = totalPayments - totalRefundAmount;
-
-    // 환불률 (%)
     double refundRate = totalPayments == 0 ? 0 : (double) totalRefundAmount / totalPayments * 100;
+    long platformProfit = Math.round(netRevenue * 0.2);
+    long managerSettlementAmount = netRevenue - platformProfit;
 
-    // 수익 배분
-    long platformProfit = Math.round(netRevenue * 0.2);  // 관리자 수익 (20%)
-    long managerSettlementAmount = netRevenue - platformProfit;  // 매니저 수익 (80%)
+    // ✅ 수익률: 플랫폼 수익 / 순매출
+    double profitRate = netRevenue == 0 ? 0 : (double) platformProfit / netRevenue * 100;
+
+    // 그래프용
+    List<DailyRevenueRefundDto> dailyStats = getLast7DaysRevenueAndRefundStats();
 
     return AdminDashboardStatsDto.builder()
         .todayRevenue(todayRevenue)
         .weeklyRevenue(weeklyRevenue)
         .monthlyRevenue(monthlyRevenue)
+        .totalPayments(totalPayments)
         .netRevenue(netRevenue)
         .totalRefundAmount(totalRefundAmount)
         .refundRate(refundRate)
         .platformProfit(platformProfit)
         .managerSettlementAmount(managerSettlementAmount)
+        .profitRate(profitRate)
+        .dailyStats(dailyStats)
         .build();
+  }
+
+
+  @Override
+  public List<DailyRevenueRefundDto> getLast7DaysRevenueAndRefundStats() {
+    List<DailyRevenueRefundDto> result = new ArrayList<>();
+
+    LocalDate today = LocalDate.now();
+    for (int i = 6; i >= 0; i--) {
+      LocalDate targetDate = today.minusDays(i);
+
+      int year = targetDate.getYear();
+      int month = targetDate.getMonthValue();
+      int day = targetDate.getDayOfMonth();
+
+      long paymentAmount = paymentRepository.sumPayments(year, month, day);
+      long refundAmount = refundRepository.sumRefundsByDate(year, month, day); // ← 이 메서드가 RefundRepository에 있어야 함
+
+      result.add(DailyRevenueRefundDto.builder()
+          .date(targetDate.toString()) // "yyyy-MM-dd"
+          .paymentAmount(paymentAmount)
+          .refundAmount(refundAmount)
+          .build());
+    }
+
+    return result;
   }
 
 }

--- a/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/dashboard/service/AdminDashboardServiceImpl.java
@@ -3,10 +3,13 @@ package com.homeaid.dashboard.service;
 
 import com.homeaid.dashboard.dto.AdminDashboardStatsDto;
 import com.homeaid.payment.repository.PaymentRepository;
+import com.homeaid.payment.repository.RefundRepository;
 import com.homeaid.repository.ManagerRepository;
 import com.homeaid.repository.ReservationRepository;
 import com.homeaid.repository.UserRepository;
 import com.homeaid.settlement.repository.SettlementRepository;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,29 +17,55 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AdminDashboardServiceImpl implements AdminDashboardService {
 
-   private final UserRepository userRepository;
-   private final ManagerRepository managerRepository;
-   private final ReservationRepository reservationRepository;
-   private final PaymentRepository paymentRepository;
-   private final SettlementRepository settlementRepository;
+  private final PaymentRepository paymentRepository;
 
+  @Override
   public AdminDashboardStatsDto getStats() {
-    long totalUsers = userRepository.countAllUsers();
-    long activeManagers = managerRepository.countActiveManagers();
-    long pendingApprovals = managerRepository.countPendingManagers();
-    long todayReservations = reservationRepository.countTodayReservations();
-    long totalPayments = paymentRepository.countAllPayments();
-    long totalPaymentAmount = paymentRepository.sumAllPaymentAmounts();
-    long totalSettlementAmount = settlementRepository.sumAllSettlementAmounts();
+    LocalDate today = LocalDate.now();
+    int year = today.getYear();
+    int month = today.getMonthValue();
+    int day = today.getDayOfMonth();
+
+    // 오늘 매출
+    long todayRevenue = paymentRepository.sumPayments(year, month, day);
+
+    // 이번 달 매출
+    long monthlyRevenue = paymentRepository.sumPayments(year, month, null);
+
+    // 이번 주 매출 (월요일 ~ 오늘)
+    LocalDate monday = today.with(DayOfWeek.MONDAY);
+    long weeklyRevenue = 0;
+    for (LocalDate date = monday; !date.isAfter(today); date = date.plusDays(1)) {
+      weeklyRevenue += paymentRepository.sumPayments(
+          date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+    }
+
+    // 전체 결제액
+    long totalPayments = paymentRepository.sumAllPaymentAmounts();
+
+    // 전체 환불 금액
+    long totalRefundAmount = paymentRepository.sumCanceledPayments(year, null, null);
+
+    // 순매출 = 전체 결제 - 환불
+    long netRevenue = totalPayments - totalRefundAmount;
+
+    // 환불률 (%)
+    double refundRate = totalPayments == 0 ? 0 : (double) totalRefundAmount / totalPayments * 100;
+
+    // 수익 배분
+    long platformProfit = Math.round(netRevenue * 0.2);  // 관리자 수익 (20%)
+    long managerSettlementAmount = netRevenue - platformProfit;  // 매니저 수익 (80%)
 
     return AdminDashboardStatsDto.builder()
-        .totalUsers(totalUsers)
-        .activeManagers(activeManagers)
-        .totalPayments(totalPayments)
-        .todayReservations(todayReservations)
-        .pendingApprovals(pendingApprovals)
-        .totalPaymentAmount(totalPaymentAmount)
-        .totalSettlementAmount(totalSettlementAmount)
+        .todayRevenue(todayRevenue)
+        .weeklyRevenue(weeklyRevenue)
+        .monthlyRevenue(monthlyRevenue)
+        .netRevenue(netRevenue)
+        .totalRefundAmount(totalRefundAmount)
+        .refundRate(refundRate)
+        .platformProfit(platformProfit)
+        .managerSettlementAmount(managerSettlementAmount)
         .build();
   }
+
 }

--- a/admin/src/main/java/com/homeaid/settlement/dto/SettlementWithManagerResponseDto.java
+++ b/admin/src/main/java/com/homeaid/settlement/dto/SettlementWithManagerResponseDto.java
@@ -69,31 +69,32 @@ public class SettlementWithManagerResponseDto {
   @Schema(description = "정산에 포함된 결제 목록")
   private List<PaymentResponseDto> payments;
 
+  public static SettlementWithManagerResponseDto from(Settlement settlement, Manager manager, List<PaymentResponseDto> payments) {
+    int actualAmount = payments.stream()
+        .mapToInt(p -> p.getNetAmount() != null ? p.getNetAmount() : 0)
+        .sum();
 
-  public static SettlementWithManagerResponseDto from(Settlement settlement, Manager manager, List<Payment> paymentList) {
-    Integer managerAmount = (int) Math.round(settlement.getTotalAmount() * 0.8);
-    Integer adminAmount = settlement.getTotalAmount() - managerAmount;
+    int managerAmount = (int) Math.round(actualAmount * 0.8);
+    int adminAmount = actualAmount - managerAmount;
 
     return SettlementWithManagerResponseDto.builder()
         .id(settlement.getId())
         .from(settlement.getSettlementWeekStart())
         .to(settlement.getSettlementWeekEnd())
-        .totalAmount(settlement.getTotalAmount())
+        .totalAmount(actualAmount)
         .managerAmount(managerAmount)
         .adminAmount(adminAmount)
         .settledAt(settlement.getSettledAt())
         .confirmedAt(settlement.getConfirmedAt())
         .paidAt(settlement.getPaidAt())
         .status(settlement.getStatus())
-
         .managerId(manager.getId())
         .managerName(manager.getName())
         .managerPhone(manager.getPhone())
         .managerEmail(manager.getEmail())
         .managerStatus(manager.getStatus())
-
-        .totalPayments(paymentList.size())
-        .payments(paymentList.stream().map(PaymentResponseDto::toDto).toList())
+        .totalPayments(payments.size())
+        .payments(payments)
         .build();
   }
 

--- a/admin/src/main/java/com/homeaid/settlement/dto/SettlementWithManagerResponseDto.java
+++ b/admin/src/main/java/com/homeaid/settlement/dto/SettlementWithManagerResponseDto.java
@@ -2,7 +2,6 @@ package com.homeaid.settlement.dto;
 
 import com.homeaid.domain.Manager;
 import com.homeaid.domain.enumerate.ManagerStatus;
-import com.homeaid.payment.domain.Payment;
 import com.homeaid.payment.dto.response.PaymentResponseDto;
 import com.homeaid.settlement.domain.Settlement;
 import com.homeaid.settlement.domain.enumerate.SettlementStatus;

--- a/admin/src/main/java/com/homeaid/settlement/scheduler/WeeklySettlementScheduler.java
+++ b/admin/src/main/java/com/homeaid/settlement/scheduler/WeeklySettlementScheduler.java
@@ -15,7 +15,7 @@ public class WeeklySettlementScheduler {
 
   private final AdminSettlementService adminSettlementService;
 
-  @Scheduled(cron = "0 0 2 * * THU") //
+  @Scheduled(cron = "0 0 1 * * Mon") //
   //@Scheduled(cron = "0 50 18 * * *")  // 매일 18:40 (오후 6시 40분) 테스트
   public void createWeeklySettlements() {
     log.info("[정산 스케줄러] 주간 정산 생성 시작");

--- a/admin/src/main/java/com/homeaid/statistics/config/StatisticsConstants.java
+++ b/admin/src/main/java/com/homeaid/statistics/config/StatisticsConstants.java
@@ -1,0 +1,23 @@
+package com.homeaid.statistics.config;
+
+import java.time.Duration;
+
+public class StatisticsConstants {
+
+  // 통계 데이터를 Redis에 저장할 때 TTL (30일)
+  public static final Duration STATISTICS_CACHE_TTL = Duration.ofDays(30);
+
+  // 스케줄러 락을 위한 TTL (중복 방지용, 10분)
+  public static final Duration STATISTICS_LOCK_TTL = Duration.ofMinutes(10);
+
+  private StatisticsConstants() {
+    // 인스턴스화 방지
+  }
+
+}
+/**
+ * 응집도(Cohesion) : StatisticsConstants는 통계 모듈에서만 쓰이는 TTL, 락 관련 상수를 담고 있으므로, 해당 도메인(statistics) 아래에 있어야 함
+ * 재사용 가능성 : 이 상수들은 다른 도메인(e.g. 결제, 유저, 정산 등)에서 사용할 일이 거의 없으므로 글로벌 위치는 부적합
+ * 관심사 분리(SRP) : 글로벌 config는 전역 설정 (JWT 설정, Spring 설정 등)을 위한 것이어야 하는데 도메인 설정을 혼합하면 모듈 구조가 흐트러짐
+ * 확장성 고려 : 나중에 통계 모듈에만 적용되는 상수가 늘어날 경우, 전용 config 패키지 아래 관리하면 훨씬 유연하게 대응
+ */

--- a/admin/src/main/java/com/homeaid/statistics/controller/AdminStatisticsController.java
+++ b/admin/src/main/java/com/homeaid/statistics/controller/AdminStatisticsController.java
@@ -1,6 +1,7 @@
 package com.homeaid.statistics.controller;
 
 import com.homeaid.common.response.CommonApiResponse;
+import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
@@ -28,99 +29,80 @@ public class AdminStatisticsController {
 
   // 회원 통계
   @GetMapping("/users")
-  @Operation(summary = "회원 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<UserStatsDto>> getUserStatistics(
+  @Operation(summary = "회원 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<UserStatsDto>> getUserStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
-    UserStatsDto dto = (month == null)
-        ? adminStatisticsService.getUserStats(year)
-        : adminStatisticsService.getUserStatsByMonth(year, month);
-
-    return ResponseEntity.ok(CommonApiResponse.success(dto));
-  }
-
-  // 탈퇴율 통계
-  @GetMapping("/withdraw-rate")
-  @Operation(summary = "탈퇴율 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<UserStatsDto>> getWithdrawRate(
-      @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
-
-    UserStatsDto dto = (month == null)
-        ? adminStatisticsService.getWithdrawalStats(year)
-        : adminStatisticsService.getWithdrawalStatsByMonth(year, month);
-
-    return ResponseEntity.ok(CommonApiResponse.success(dto));
+    return ResponseEntity.ok(CommonApiResponse.success(
+        adminStatisticsService.getUserStats(year, month, day)
+    ));
   }
 
   // 정산 통계
   @GetMapping("/settlements")
-  @Operation(summary = "정산 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<SettlementStatsDto>> getSettlementStatistics(
+  @Operation(summary = "정산 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<SettlementStatsDto>> getSettlementStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
-    SettlementStatsDto dto = (month == null)
-        ? adminStatisticsService.getSettlementStats(year)
-        : adminStatisticsService.getSettlementStatsByMonth(year, month);
-
-    return ResponseEntity.ok(CommonApiResponse.success(dto));
+    return ResponseEntity.ok(CommonApiResponse.success(
+        adminStatisticsService.getSettlementStats(year, month, day)
+    ));
   }
 
-  /// 결제 통계 (연간 총액 / 월간 총액 + 수단별)
+  // 결제 통계
   @GetMapping("/payments")
-  @Operation(summary = "결제 통계")
+  @Operation(summary = "결제 통계 (연/월/일 선택)")
   public ResponseEntity<CommonApiResponse<PaymentStatsDto>> getPaymentStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
-    PaymentStatsDto result = (month == null)
-        ? adminStatisticsService.getPaymentStats(year)
-        : adminStatisticsService.getPaymentStatsByMonth(year, month);
-
-    return ResponseEntity.ok(CommonApiResponse.success(result));
+    return ResponseEntity.ok(CommonApiResponse.success(
+        adminStatisticsService.getPaymentStats(year, month, day)
+    ));
   }
 
   // 예약 통계
   @GetMapping("/reservations")
-  @Operation(summary = "예약 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<ReservationStatsDto>> getReservationStatistics(
+  @Operation(summary = "예약 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<ReservationStatsDto>> getReservationStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
     return ResponseEntity.ok(CommonApiResponse.success(
-        adminStatisticsService.getReservationStats(year, month)
+        adminStatisticsService.getReservationStats(year, month, day)
     ));
   }
 
-  // 매칭 성공 통계
-  @GetMapping("/matching/success")
-  @Operation(summary = "매칭 성공 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<MatchingStatsDto>> getMatchingSuccessStats(
+  // 매칭 통계
+  @GetMapping("/matching")
+  @Operation(summary = "매칭 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<MatchingStatsDto>> getMatchingStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
     return ResponseEntity.ok(CommonApiResponse.success(
-        adminStatisticsService.getMatchingSuccessStats(year, month)
+        adminStatisticsService.getMatchingStats(year, month, day)
     ));
   }
 
-  // 매칭 실패/취소 통계
-  @GetMapping("/matching/fail")
-  @Operation(summary = "매칭 실패/취소 통계 (연간 또는 월간)")
-  public ResponseEntity<CommonApiResponse<MatchingStatsDto>> getMatchingFailStats(
+  // 매니저 평점 통계
+  @GetMapping("/manager-ratings")
+  @Operation(summary = "매니저 평점 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<ManagerRatingStatsDto>> getManagerRatingStats(
       @RequestParam int year,
-      @RequestParam(required = false) Integer month) {
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
 
     return ResponseEntity.ok(CommonApiResponse.success(
-        adminStatisticsService.getMatchingFailStats(year, month)
+        adminStatisticsService.getManagerRatingStats(year, month, day)
     ));
   }
 
-  // 서비스 품질 (평점 평균) 통계 추후 구현 시 아래 참고
-  // @GetMapping("/manager/ratings")
-  // public ResponseEntity<CommonApiResponse<ManagerRatingStatsDto>> getManagerRatingStats(@RequestParam int year) {
-  //   return ResponseEntity.ok(CommonApiResponse.success(adminStatisticsService.getManagerRatingStats(year)));
-  // }
 }

--- a/admin/src/main/java/com/homeaid/statistics/controller/AdminStatisticsController.java
+++ b/admin/src/main/java/com/homeaid/statistics/controller/AdminStatisticsController.java
@@ -1,14 +1,20 @@
 package com.homeaid.statistics.controller;
 
 import com.homeaid.common.response.CommonApiResponse;
+import com.homeaid.exception.CustomException;
+import com.homeaid.statistics.dto.AdminStatisticsDto;
 import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
 import com.homeaid.statistics.dto.SettlementStatsDto;
 import com.homeaid.statistics.dto.UserStatsDto;
+import com.homeaid.statistics.exception.StatisticsErrorCode;
 import com.homeaid.statistics.service.AdminStatisticsService;
+import com.homeaid.util.RedisKeyFactory;
+import com.homeaid.util.RedisUtil;
 import io.swagger.v3.oas.annotations.Operation;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -23,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('ADMIN')")
 public class AdminStatisticsController {
 
+  private final RedisUtil redisUtil;
   private final AdminStatisticsService adminStatisticsService;
 
   // TODO : 데이터가 Null 일 경우에 대한 방어로직 추가
@@ -103,6 +110,30 @@ public class AdminStatisticsController {
     return ResponseEntity.ok(CommonApiResponse.success(
         adminStatisticsService.getManagerRatingStats(year, month, day)
     ));
+  }
+
+  @GetMapping("/all")
+  @Operation(summary = "전체 통계 (연/월/일 선택)")
+  public ResponseEntity<CommonApiResponse<AdminStatisticsDto>> getAllStatistics(
+      @RequestParam int year,
+      @RequestParam(required = false) Integer month,
+      @RequestParam(required = false) Integer day) {
+
+    String key = RedisKeyFactory.buildAdminStatisticsKey(year, month, day);
+    AdminStatisticsDto dto = (AdminStatisticsDto) redisUtil.getObject(key);
+
+    if (dto == null) {
+      // Redis 미존재 시 DB fallback + Redis 재저장
+      dto = adminStatisticsService.getStatisticsOrLoad(year, month, day);
+      redisUtil.save(key, dto, Duration.ofDays(30));
+    }
+
+    // 최종 null 체크
+    if (dto == null) {
+      throw new CustomException(StatisticsErrorCode.STATISTICS_NOT_FOUND);
+    }
+
+    return ResponseEntity.ok(CommonApiResponse.success(dto));
   }
 
 }

--- a/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
+++ b/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
@@ -1,6 +1,7 @@
 package com.homeaid.statistics.domain;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.homeaid.exception.CustomException;
 import com.homeaid.statistics.dto.AdminStatisticsDto;
@@ -67,8 +68,9 @@ public class StatisticsEntity {
 
   public AdminStatisticsDto toDto() {
     try {
-      ObjectMapper mapper = new ObjectMapper();
-      return mapper.readValue(this.jsonData, AdminStatisticsDto.class); // JSON 문자열 → DTO
+      ObjectMapper mapper = new ObjectMapper()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      return mapper.readValue(this.jsonData, AdminStatisticsDto.class);
     } catch (JsonProcessingException e) {
       throw new CustomException(StatisticsErrorCode.STATISTICS_DESERIALIZATION_FAILED);
     }

--- a/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
+++ b/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
@@ -1,0 +1,69 @@
+package com.homeaid.statistics.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.homeaid.exception.CustomException;
+import com.homeaid.statistics.dto.AdminStatisticsDto;
+import com.homeaid.statistics.exception.StatisticsErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+@Entity
+@Table(name = "admin_statistics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class StatisticsEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private int year;
+  private Integer month;
+  private Integer day;
+
+  @Lob
+  private String jsonData; // AdminStatisticsDto 전체를 JSON 문자열로 저장
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  public static StatisticsEntity fromDto(AdminStatisticsDto dto) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      return StatisticsEntity.builder()
+          .year(dto.getYear())
+          .month(dto.getMonth())
+          .day(dto.getDay())
+          .jsonData(mapper.writeValueAsString(dto)) // DTO → JSON 문자열
+          .build();
+    } catch (JsonProcessingException e) {
+      throw new CustomException(StatisticsErrorCode.STATISTICS_SERIALIZATION_FAILED);
+    }
+  }
+
+  public AdminStatisticsDto toDto() {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      return mapper.readValue(this.jsonData, AdminStatisticsDto.class); // JSON 문자열 → DTO
+    } catch (JsonProcessingException e) {
+      throw new CustomException(StatisticsErrorCode.STATISTICS_DESERIALIZATION_FAILED);
+    }
+  }
+
+}

--- a/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
+++ b/admin/src/main/java/com/homeaid/statistics/domain/StatisticsEntity.java
@@ -7,6 +7,7 @@ import com.homeaid.statistics.dto.AdminStatisticsDto;
 import com.homeaid.statistics.exception.StatisticsErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,6 +20,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "admin_statistics")
@@ -26,6 +29,7 @@ import org.springframework.data.annotation.CreatedDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(AuditingEntityListener.class)
 public class StatisticsEntity {
 
   @Id
@@ -40,8 +44,12 @@ public class StatisticsEntity {
   private String jsonData; // AdminStatisticsDto 전체를 JSON 문자열로 저장
 
   @CreatedDate
-  @Column(updatable = false)
+  @Column(updatable = false, nullable = false)
   private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt; // 마지막 갱신 시점 자동 기록
 
   public static StatisticsEntity fromDto(AdminStatisticsDto dto) {
     try {

--- a/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
@@ -1,10 +1,16 @@
 package com.homeaid.statistics.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AdminStatisticsDto {
   private int year;
   private Integer month;

--- a/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
@@ -16,4 +16,5 @@ public class AdminStatisticsDto {
   private MatchingStatsDto matchingStats;
   private SettlementStatsDto settlementStats;
   private ManagerRatingStatsDto managerRatingStats;
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/AdminStatisticsDto.java
@@ -1,0 +1,19 @@
+package com.homeaid.statistics.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminStatisticsDto {
+  private int year;
+  private Integer month;
+  private Integer day;
+
+  private UserStatsDto userStats;
+  private PaymentStatsDto paymentStats;
+  private ReservationStatsDto reservationStats;
+  private MatchingStatsDto matchingStats;
+  private SettlementStatsDto settlementStats;
+  private ManagerRatingStatsDto managerRatingStats;
+}

--- a/admin/src/main/java/com/homeaid/statistics/dto/ManagerRatingStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/ManagerRatingStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/ManagerRatingStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/ManagerRatingStatsDto.java
@@ -14,9 +14,16 @@ public class ManagerRatingStatsDto {
 
   @Schema(description = "연도", example = "2025")
   private int year;
+
   @Schema(description = "월 (선택, 1~12)", example = "6")
   private Integer month;
 
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
+
   @Schema(description = "매니저 평균 평점", example = "4.52")
   private double avgRating;
+
+  @Schema(description = "평점 수 (리뷰 수)", example = "345")
+  private long reviewCount;
 }

--- a/admin/src/main/java/com/homeaid/statistics/dto/MatchingStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/MatchingStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/MatchingStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/MatchingStatsDto.java
@@ -14,13 +14,20 @@ public class MatchingStatsDto {
 
   @Schema(description = "연도", example = "2025")
   private int year;
+
   @Schema(description = "월 (선택, 1~12)", example = "6")
   private Integer month;
+
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
 
   @Schema(description = "성공 매칭 수", example = "1000")
   private long successCount;
 
   @Schema(description = "실패/취소 매칭 수", example = "300")
   private long failCount;
+
+  @Schema(description = "전체 매칭 시도 수", example = "1300")
+  private long totalCount;
 
 }

--- a/admin/src/main/java/com/homeaid/statistics/dto/PaymentStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/PaymentStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/PaymentStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/PaymentStatsDto.java
@@ -15,19 +15,30 @@ public class PaymentStatsDto {
   @Schema(description = "연도", example = "2025")
   private int year;
 
+  @Schema(description = "월 (선택, 1~12)", example = "6")
+  private Integer month;
+
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
+
   @Schema(description = "총 결제 금액", example = "15000000")
   private long totalAmount;
 
   @Schema(description = "취소 금액", example = "2000000")
   private long cancelAmount;
 
-  @Schema(description = "월 (선택, 1~12)", example = "6")
-  private Integer month;
+  @Schema(description = "결제 건수", example = "370")
+  private long paymentCount;
+
+  @Schema(description = "취소 건수", example = "12")
+  private long cancelCount;
 
   @Schema(description = "카드 결제 금액", example = "1000000")
   private long card;
+
   @Schema(description = "계좌이체 결제 금액", example = "200000")
   private long transfer;
+
   @Schema(description = "현금 결제 금액", example = "50000")
   private long cash;
 }

--- a/admin/src/main/java/com/homeaid/statistics/dto/ReservationStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/ReservationStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/ReservationStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/ReservationStatsDto.java
@@ -14,12 +14,23 @@ public class ReservationStatsDto {
 
   @Schema(description = "연도", example = "2025")
   private int year;
+
   @Schema(description = "월 (선택, 1~12)", example = "6")
   private Integer month;
+
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
 
   @Schema(description = "총 예약 수", example = "1800")
   private long reservationCount;
 
+  @Schema(description = "예약 취소 수", example = "123")
+  private long cancelledCount;
+
   @Schema(description = "예약 평균 처리 시간 (분 단위)", example = "15")
   private double avgProcessingMinutes;
+
+  @Schema(description = "예약 성공률 (%)", example = "87.5")
+  private double reservationSuccessRate;
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/dto/SettlementStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/SettlementStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/SettlementStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/SettlementStatsDto.java
@@ -14,8 +14,12 @@ public class SettlementStatsDto {
 
   @Schema(description = "연도", example = "2025")
   private int year;
+
   @Schema(description = "월 (선택, 1~12)", example = "6")
   private Integer month;
+
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
 
   @Schema(description = "정산 신청 수", example = "300")
   private long requestedCount;

--- a/admin/src/main/java/com/homeaid/statistics/dto/UserStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/UserStatsDto.java
@@ -5,8 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/admin/src/main/java/com/homeaid/statistics/dto/UserStatsDto.java
+++ b/admin/src/main/java/com/homeaid/statistics/dto/UserStatsDto.java
@@ -14,8 +14,12 @@ public class UserStatsDto {
 
   @Schema(description = "해당 연도", example = "2025")
   private int year;
+
   @Schema(description = "월 (선택, 1~12)", example = "6")
   private Integer month;
+
+  @Schema(description = "일 (선택, 1~31)", example = "9")
+  private Integer day;
 
   @Schema(description = "가입자 수", example = "1234")
   private long signupCount;
@@ -26,12 +30,4 @@ public class UserStatsDto {
   @Schema(description = "탈퇴 회원 수", example = "120")
   private long withdrawCount;
 
-  @Schema(description = "마지막 로그인 6개월 이상 미접속 회원 수", example = "300")
-  private long inactiveUserCount;
-
-  @Schema(description = "탈퇴율 (퍼센트)", example = "13.5")
-  private double withdrawRate;
-
-  @Schema(description = "휴면자 수", example = "90")
-  private long dormantCount;
 }

--- a/admin/src/main/java/com/homeaid/statistics/exception/StatisticsErrorCode.java
+++ b/admin/src/main/java/com/homeaid/statistics/exception/StatisticsErrorCode.java
@@ -10,7 +10,12 @@ public enum StatisticsErrorCode implements BaseErrorCode {
   STATISTICS_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STATISTICS_SERIALIZATION_FAILED", "통계 JSON 직렬화에 실패했습니다."),
   STATISTICS_DESERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STATISTICS_DESERIALIZATION_FAILED", "통계 JSON 역직렬화에 실패했습니다."),
   STATISTICS_NOT_FOUND(HttpStatus.NOT_FOUND, "STATISTICS_NOT_FOUND", "요청한 날짜의 통계 데이터가 존재하지 않습니다."),
-  STATISTICS_REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "STATISTICS_REDIS_CONNECTION_FAILED", "Redis 연결에 실패했습니다.");
+  STATISTICS_REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "STATISTICS_REDIS_CONNECTION_FAILED", "Redis 연결에 실패했습니다."),
+
+  // 파라미터 유효성 검사 관련 에러 추가
+  INVALID_YEAR(HttpStatus.BAD_REQUEST, "INVALID_YEAR", "유효하지 않은 연도입니다."),
+  INVALID_MONTH(HttpStatus.BAD_REQUEST, "INVALID_MONTH", "유효하지 않은 월입니다."),
+  INVALID_DAY(HttpStatus.BAD_REQUEST, "INVALID_DAY", "유효하지 않은 일자입니다.");
 
   private final HttpStatus status;
   private final String code;

--- a/admin/src/main/java/com/homeaid/statistics/exception/StatisticsErrorCode.java
+++ b/admin/src/main/java/com/homeaid/statistics/exception/StatisticsErrorCode.java
@@ -1,0 +1,25 @@
+package com.homeaid.statistics.exception;
+
+import com.homeaid.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum StatisticsErrorCode implements BaseErrorCode {
+
+  STATISTICS_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STATISTICS_SERIALIZATION_FAILED", "통계 JSON 직렬화에 실패했습니다."),
+  STATISTICS_DESERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STATISTICS_DESERIALIZATION_FAILED", "통계 JSON 역직렬화에 실패했습니다."),
+  STATISTICS_NOT_FOUND(HttpStatus.NOT_FOUND, "STATISTICS_NOT_FOUND", "요청한 날짜의 통계 데이터가 존재하지 않습니다."),
+  STATISTICS_REDIS_CONNECTION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "STATISTICS_REDIS_CONNECTION_FAILED", "Redis 연결에 실패했습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  StatisticsErrorCode(HttpStatus status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/ManagerRatingStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/ManagerRatingStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.ManagerRatingStatsDto;
+
+public interface ManagerRatingStatisticsProvider {
+  ManagerRatingStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/MatchingStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/MatchingStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.MatchingStatsDto;
+
+public interface MatchingStatisticsProvider {
+  MatchingStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/PaymentStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/PaymentStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.PaymentStatsDto;
+
+public interface PaymentStatisticsProvider {
+  PaymentStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/ReservationStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/ReservationStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.ReservationStatsDto;
+
+public interface ReservationStatisticsProvider {
+  ReservationStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/SettlementStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/SettlementStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.SettlementStatsDto;
+
+public interface SettlementStatisticsProvider {
+  SettlementStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/UserStatisticsProvider.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/UserStatisticsProvider.java
@@ -1,0 +1,7 @@
+package com.homeaid.statistics.provider;
+
+import com.homeaid.statistics.dto.UserStatsDto;
+
+public interface UserStatisticsProvider {
+  UserStatsDto generate(int year, Integer month, Integer day);
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/ManagerRatingStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/ManagerRatingStatisticsProviderImpl.java
@@ -1,0 +1,28 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.repository.ReviewRepository;
+import com.homeaid.statistics.dto.ManagerRatingStatsDto;
+import com.homeaid.statistics.provider.ManagerRatingStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ManagerRatingStatisticsProviderImpl implements ManagerRatingStatisticsProvider {
+
+  private final ReviewRepository reviewRepository;
+
+  @Override
+  public ManagerRatingStatsDto generate(int year, Integer month, Integer day) {
+    Double avg = reviewRepository.findAvgRatingForManagers(year, month, day);
+    Long count = reviewRepository.countReviewsForManagers(year, month, day);
+
+    return ManagerRatingStatsDto.builder()
+        .year(year)
+        .month(month)
+        .day(day)
+        .avgRating(avg != null ? avg : 0.0)
+        .reviewCount(count != null ? count : 0L)
+        .build();
+  }
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/MatchingStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/MatchingStatisticsProviderImpl.java
@@ -1,0 +1,30 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.repository.MatchingRepository;
+import com.homeaid.statistics.dto.MatchingStatsDto;
+import com.homeaid.statistics.provider.MatchingStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingStatisticsProviderImpl implements MatchingStatisticsProvider {
+
+  private final MatchingRepository matchingRepository;
+
+  @Override
+  public MatchingStatsDto generate(int year, Integer month, Integer day) {
+    long success = matchingRepository.countConfirmedMatchings(year, month, day);
+    long fail = matchingRepository.countFailedOrCancelledMatchings(year, month, day);
+    long total = matchingRepository.countTotalMatchings(year, month, day);
+
+    return MatchingStatsDto.builder()
+        .year(year)
+        .month(month)
+        .day(day)
+        .successCount(success)
+        .failCount(fail)
+        .totalCount(total)
+        .build();
+  }
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/PaymentStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/PaymentStatisticsProviderImpl.java
@@ -1,0 +1,43 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.payment.repository.PaymentRepository;
+import com.homeaid.statistics.dto.PaymentStatsDto;
+import com.homeaid.statistics.provider.PaymentStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentStatisticsProviderImpl implements PaymentStatisticsProvider {
+
+  private final PaymentRepository paymentRepository;
+
+  @Override
+  public PaymentStatsDto generate(int year, Integer month, Integer day) {
+    long total = paymentRepository.sumPayments(year, month, day);
+    long canceled = paymentRepository.sumCanceledPayments(year, month, day);
+    long paymentCount = paymentRepository.countPayments(year, month, day);
+    long cancelCount = paymentRepository.countCanceledPayments(year, month, day);
+
+    PaymentStatsDto.PaymentStatsDtoBuilder builder = PaymentStatsDto.builder()
+        .year(year).month(month).day(day)
+        .totalAmount(total)
+        .cancelAmount(canceled)
+        .paymentCount(paymentCount)
+        .cancelCount(cancelCount);
+
+    // 결제 수단별 통계는 "월 통계"일 때만 포함
+    if (month != null && day == null) {
+      Object result = paymentRepository.findPaymentMethodSums(year, month);
+      if (result instanceof Object[] values && values.length == 3) {
+        builder.card(((Number) values[0]).longValue());
+        builder.transfer(((Number) values[1]).longValue());
+        builder.cash(((Number) values[2]).longValue());
+      } else {
+        builder.card(0L).transfer(0L).cash(0L);
+      }
+    }
+
+    return builder.build();
+  }
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/PaymentStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/PaymentStatisticsProviderImpl.java
@@ -19,15 +19,14 @@ public class PaymentStatisticsProviderImpl implements PaymentStatisticsProvider 
     long paymentCount = paymentRepository.countPayments(year, month, day);
     long cancelCount = paymentRepository.countCanceledPayments(year, month, day);
 
-    PaymentStatsDto.PaymentStatsDtoBuilder builder = PaymentStatsDto.builder()
+    var builder = PaymentStatsDto.builder()
         .year(year).month(month).day(day)
         .totalAmount(total)
         .cancelAmount(canceled)
         .paymentCount(paymentCount)
         .cancelCount(cancelCount);
 
-    // 결제 수단별 통계는 "월 통계"일 때만 포함
-    if (month != null && day == null) {
+    if (shouldIncludePaymentMethodStats(month, day)) {
       Object result = paymentRepository.findPaymentMethodSums(year, month);
       if (result instanceof Object[] values && values.length == 3) {
         builder.card(((Number) values[0]).longValue());
@@ -40,4 +39,9 @@ public class PaymentStatisticsProviderImpl implements PaymentStatisticsProvider 
 
     return builder.build();
   }
+
+  private boolean shouldIncludePaymentMethodStats(Integer month, Integer day) {
+    return month != null && day == null;
+  }
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/ReservationStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/ReservationStatisticsProviderImpl.java
@@ -1,0 +1,34 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.repository.ReservationRepository;
+import com.homeaid.statistics.dto.ReservationStatsDto;
+import com.homeaid.statistics.provider.ReservationStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationStatisticsProviderImpl implements ReservationStatisticsProvider {
+
+  private final ReservationRepository reservationRepository;
+
+  @Override
+  public ReservationStatsDto generate(int year, Integer month, Integer day) {
+    long reservationCount = reservationRepository.countReservations(year, month, day);
+    long cancelledCount = reservationRepository.countCancelledReservations(year, month, day);
+    Double avgMinutes = reservationRepository.getAverageProcessingMinutes(year, month, day);
+    long completedCount = reservationRepository.countCompletedReservations(year, month, day);
+
+    double successRate = (reservationCount > 0)
+        ? (completedCount * 100.0 / reservationCount)
+        : 0.0;
+
+    return ReservationStatsDto.builder()
+        .year(year).month(month).day(day)
+        .reservationCount(reservationCount)
+        .cancelledCount(cancelledCount)
+        .avgProcessingMinutes(avgMinutes != null ? avgMinutes : 0.0)
+        .reservationSuccessRate(successRate)
+        .build();
+  }
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/SettlementStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/SettlementStatisticsProviderImpl.java
@@ -1,0 +1,28 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.settlement.repository.SettlementRepository;
+import com.homeaid.statistics.dto.SettlementStatsDto;
+import com.homeaid.statistics.provider.SettlementStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementStatisticsProviderImpl implements SettlementStatisticsProvider {
+
+  private final SettlementRepository settlementRepository;
+
+  @Override
+  public SettlementStatsDto generate(int year, Integer month, Integer day) {
+    long requested = settlementRepository.countRequested(year, month, day);
+    long paid = settlementRepository.countPaid(year, month, day);
+
+    return SettlementStatsDto.builder()
+        .year(year)
+        .month(month)
+        .day(day)
+        .requestedCount(requested)
+        .paidCount(paid)
+        .build();
+  }
+}

--- a/admin/src/main/java/com/homeaid/statistics/provider/impl/UserStatisticsProviderImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/provider/impl/UserStatisticsProviderImpl.java
@@ -1,0 +1,27 @@
+package com.homeaid.statistics.provider.impl;
+
+import com.homeaid.repository.UserRepository;
+import com.homeaid.statistics.dto.UserStatsDto;
+import com.homeaid.statistics.provider.UserStatisticsProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserStatisticsProviderImpl implements UserStatisticsProvider {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public UserStatsDto generate(int year, Integer month, Integer day) {
+    return UserStatsDto.builder()
+        .year(year)
+        .month(month)
+        .day(day)
+        .signupCount(userRepository.countSignUps(year, month, day))
+        .totalUsers(userRepository.count())
+        .withdrawCount(userRepository.countWithdrawn(year, month, day))
+        .build();
+  }
+
+}

--- a/admin/src/main/java/com/homeaid/statistics/repository/StatisticsRepository.java
+++ b/admin/src/main/java/com/homeaid/statistics/repository/StatisticsRepository.java
@@ -3,12 +3,23 @@ package com.homeaid.statistics.repository;
 import com.homeaid.statistics.domain.StatisticsEntity;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StatisticsRepository extends JpaRepository<StatisticsEntity, Long> {
 
-  Optional<StatisticsEntity> findByYearAndMonthAndDay(int year, Integer month, Integer day);
+  //Optional<StatisticsEntity> findByYearAndMonthAndDay(int year, Integer month, Integer day);
+  @Query("""
+  SELECT s FROM StatisticsEntity s
+  WHERE s.year = :year
+    AND (:month IS NULL OR s.month = :month)
+    AND (:day IS NULL OR s.day = :day)
+  """)
+  Optional<StatisticsEntity> findByDate(@Param("year") int year,
+      @Param("month") Integer month,
+      @Param("day") Integer day);
 
 }
 // 날짜별로 저장된 통계 데이터를 DB에서 fallback 조회할 때도 활용

--- a/admin/src/main/java/com/homeaid/statistics/repository/StatisticsRepository.java
+++ b/admin/src/main/java/com/homeaid/statistics/repository/StatisticsRepository.java
@@ -1,0 +1,14 @@
+package com.homeaid.statistics.repository;
+
+import com.homeaid.statistics.domain.StatisticsEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StatisticsRepository extends JpaRepository<StatisticsEntity, Long> {
+
+  Optional<StatisticsEntity> findByYearAndMonthAndDay(int year, Integer month, Integer day);
+
+}
+// 날짜별로 저장된 통계 데이터를 DB에서 fallback 조회할 때도 활용

--- a/admin/src/main/java/com/homeaid/statistics/scheduler/AdminStatisticsScheduler.java
+++ b/admin/src/main/java/com/homeaid/statistics/scheduler/AdminStatisticsScheduler.java
@@ -1,0 +1,63 @@
+package com.homeaid.statistics.scheduler;
+
+import com.homeaid.statistics.dto.MatchingStatsDto;
+import com.homeaid.statistics.dto.PaymentStatsDto;
+import com.homeaid.statistics.dto.ReservationStatsDto;
+import com.homeaid.statistics.dto.SettlementStatsDto;
+import com.homeaid.statistics.dto.UserStatsDto;
+import com.homeaid.statistics.service.AdminStatisticsService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AdminStatisticsScheduler {
+
+  private final AdminStatisticsService adminStatisticsService;
+
+  @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시 실행
+  public void runScheduledStatistics() {
+    LocalDate today = LocalDate.now();
+    int year = today.getYear();
+    int month = today.getMonthValue();
+    int day = today.getDayOfMonth();
+
+    log.info("[스케줄러] {}년 {}월 {}일 통계 계산 시작", year, month, day);
+
+    try {
+      log.info("→ 회원 통계 계산");
+      UserStatsDto userStats = adminStatisticsService.getUserStats(year, month, day);
+      log.info("회원 통계: {}", userStats);
+
+      log.info("→ 결제 통계 계산");
+      PaymentStatsDto paymentStats = adminStatisticsService.getPaymentStats(year, month, null); // 월간 통계
+      log.info("결제 통계(월간): {}", paymentStats);
+
+      log.info("→ 일별 결제 통계 계산");
+      PaymentStatsDto dailyPaymentStats = adminStatisticsService.getPaymentStats(year, month, day); // 일별 통계
+      log.info("결제 통계(일간): {}", dailyPaymentStats);
+
+      log.info("→ 예약 통계 계산");
+      ReservationStatsDto reservationStats = adminStatisticsService.getReservationStats(year, month, day);
+      log.info("예약 통계: {}", reservationStats);
+
+      log.info("→ 매칭 통계 계산");
+      MatchingStatsDto matchingStats = adminStatisticsService.getMatchingStats(year, month, day);
+      log.info("매칭 통계: {}", matchingStats);
+
+      log.info("→ 정산 통계 계산");
+      SettlementStatsDto settlementStats = adminStatisticsService.getSettlementStats(year, month, day);
+      log.info("정산 통계: {}", settlementStats);
+
+    } catch (Exception e) {
+      log.error("스케줄링 통계 처리 중 오류 발생: {}", e.getMessage(), e);
+    }
+
+    log.info("[스케줄러] {}년 {}월 {}일 통계 계산 완료", year, month, day);
+  }
+
+}

--- a/admin/src/main/java/com/homeaid/statistics/scheduler/AdminStatisticsScheduler.java
+++ b/admin/src/main/java/com/homeaid/statistics/scheduler/AdminStatisticsScheduler.java
@@ -20,7 +20,7 @@ public class AdminStatisticsScheduler {
   private final AdminStatisticsService adminStatisticsService;
   private final RedisUtil redisUtil;
 
-  @Scheduled(cron = "0 0 3 * * *") // 매일 새벽 3시
+  @Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
   public void runScheduledStatistics() {
 
     // 전날 기준으로 통계 생성 - 7월 9일 새벽 3시에 실행된 스케줄러는 7월 8일 통계를 계산해야 함

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
@@ -1,5 +1,6 @@
 package com.homeaid.statistics.service;
 
+import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
@@ -9,34 +10,20 @@ import com.homeaid.statistics.dto.UserStatsDto;
 public interface AdminStatisticsService {
 
   // 회원 통계
-  UserStatsDto getUserStats(int year);
-  UserStatsDto getUserStatsByMonth(int year, int month);
-  UserStatsDto getWithdrawalStatsByMonth(int year, int month);
+  UserStatsDto getUserStats(int year, Integer month, Integer day);
 
   // 정산 통계
-  SettlementStatsDto getSettlementStats(int year);
-  SettlementStatsDto getSettlementStatsByMonth(int year, int month);
+  SettlementStatsDto getSettlementStats(int year, Integer month, Integer day);
 
   // 결제 통계
-  PaymentStatsDto getPaymentStats(int year);
-  PaymentStatsDto getPaymentStatsByMonth(int year, int month);
+  PaymentStatsDto getPaymentStats(int year, Integer month, Integer day);
 
   // 예약 통계
-  ReservationStatsDto getReservationStats(int year, Integer month);
-
-  // 수익 통계
-  //ProfitStatsDto getProfitStats(int year);
-
-  // 이탈 통계
-  UserStatsDto getWithdrawalStats(int year);
+  ReservationStatsDto getReservationStats(int year, Integer month, Integer day);
 
   // 매칭 통계
-  MatchingStatsDto getMatchingSuccessStats(int year, Integer month);
-  MatchingStatsDto getMatchingFailStats(int year, Integer month);
-
-  // CS 통계
-  //InquiryStatsDto getInquiryStats(int year);
+  MatchingStatsDto getMatchingStats(int year, Integer month, Integer day);
 
   // 서비스 품질 통계
-  //ManagerRatingStatsDto getManagerRatingStats(int year);
+  ManagerRatingStatsDto getManagerRatingStats(int year, Integer month, Integer day);
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
@@ -34,4 +34,7 @@ public interface AdminStatisticsService {
   // Redis → DB fallback 통계 조회
   AdminStatisticsDto getStatisticsOrLoad(int year, Integer month, Integer day);
 
+  // 통계 생성 및 Redis + DB 저장 (스케줄러 등에서 사용)
+  void generateAndStoreStatistics(int year, Integer month, Integer day);
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
@@ -1,5 +1,6 @@
 package com.homeaid.statistics.service;
 
+import com.homeaid.statistics.dto.AdminStatisticsDto;
 import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
@@ -26,4 +27,11 @@ public interface AdminStatisticsService {
 
   // 서비스 품질 통계
   ManagerRatingStatsDto getManagerRatingStats(int year, Integer month, Integer day);
+
+  // Redis 및 DB에 저장
+  void saveStatisticsToRedisAndDb(AdminStatisticsDto dto);
+
+  // Redis → DB fallback 통계 조회
+  AdminStatisticsDto getStatisticsOrLoad(int year, Integer month, Integer day);
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsService.java
@@ -28,9 +28,6 @@ public interface AdminStatisticsService {
   // 서비스 품질 통계
   ManagerRatingStatsDto getManagerRatingStats(int year, Integer month, Integer day);
 
-  // Redis 및 DB에 저장
-  void saveStatisticsToRedisAndDb(AdminStatisticsDto dto);
-
   // Redis → DB fallback 통계 조회
   AdminStatisticsDto getStatisticsOrLoad(int year, Integer month, Integer day);
 

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
@@ -1,16 +1,5 @@
 package com.homeaid.statistics.service;
 
-import static com.homeaid.statistics.config.StatisticsConstants.STATISTICS_CACHE_TTL;
-
-import com.homeaid.exception.CustomException;
-import com.homeaid.payment.repository.PaymentRepository;
-import com.homeaid.repository.MatchingRepository;
-import com.homeaid.repository.ReservationRepository;
-import com.homeaid.repository.ReviewRepository;
-import com.homeaid.repository.UserRepository;
-import com.homeaid.settlement.repository.SettlementRepository;
-import com.homeaid.statistics.config.StatisticsConstants;
-import com.homeaid.statistics.domain.StatisticsEntity;
 import com.homeaid.statistics.dto.AdminStatisticsDto;
 import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
@@ -18,16 +7,12 @@ import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
 import com.homeaid.statistics.dto.SettlementStatsDto;
 import com.homeaid.statistics.dto.UserStatsDto;
-import com.homeaid.statistics.exception.StatisticsErrorCode;
 import com.homeaid.statistics.provider.ManagerRatingStatisticsProvider;
 import com.homeaid.statistics.provider.MatchingStatisticsProvider;
 import com.homeaid.statistics.provider.PaymentStatisticsProvider;
 import com.homeaid.statistics.provider.ReservationStatisticsProvider;
 import com.homeaid.statistics.provider.SettlementStatisticsProvider;
 import com.homeaid.statistics.provider.UserStatisticsProvider;
-import com.homeaid.statistics.repository.StatisticsRepository;
-import com.homeaid.util.RedisKeyFactory;
-import com.homeaid.util.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -44,10 +29,8 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
   private final SettlementStatisticsProvider settlementStatisticsProvider;
   private final ManagerRatingStatisticsProvider managerRatingStatisticsProvider;
 
-  private final ReviewRepository reviewRepository; // 매니저 전체 평균 평점, 매니저 대상 총 리뷰 수
-
-  private final RedisUtil redisUtil;
-  private final StatisticsRepository statisticsRepository;
+  // Redis & DB 저장/조회 책임 분리
+  private final AdminStatisticsStorageService storageService;
 
   @Override
   public UserStatsDto getUserStats(int year, Integer month, Integer day) {
@@ -96,68 +79,19 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
   }
 
   /**
-   * 통계 데이터를 Redis에 저장하고, DB에도 백업 (매일 스케줄러에서 호출)
-   * - Redis TTL 30일
-   * - DB에는 JSON으로 저장 (StatisticsEntity)
-   */
-  public void saveStatisticsToRedisAndDb(AdminStatisticsDto dto) {
-    String key = RedisKeyFactory.buildAdminStatisticsKey(dto.getYear(), dto.getMonth(), dto.getDay());
-    redisUtil.save(key, dto, STATISTICS_CACHE_TTL); // Redis TTL은 상수로 관리하여 유지보수 용이하게 설정
-
-    StatisticsEntity entity = StatisticsEntity.fromDto(dto);
-    statisticsRepository.save(entity);
-  }
-
-  /**
-   * Redis 조회 후 없으면 DB fallback (Controller에서 활용)
+   * Redis에서 조회, 없으면 DB fallback
    */
   @Override
   public AdminStatisticsDto getStatisticsOrLoad(int year, Integer month, Integer day) {
-    String key = RedisKeyFactory.buildAdminStatisticsKey(year, month, day);
-
-    // 1. Redis 우선 조회
-    Object cached = redisUtil.getObject(key);
-    if (cached instanceof AdminStatisticsDto cachedDto) {
-      log.info("[캐시 HIT] Redis에서 통계 데이터 조회 - key: {}", key);
-      return cachedDto;
-    }
-
-    if (cached != null) {
-      log.warn("[캐시 MISS] Redis 값은 존재하지만 AdminStatisticsDto 타입이 아님 - key: {}", key);
-    } else {
-      log.warn("[캐시 MISS] Redis에 해당 통계 데이터 없음 - key: {}", key);
-    }
-
-    // 2. DB fallback
-    return statisticsRepository.findByYearAndMonthAndDay(year, month, day)
-        .map(entity -> {
-          try {
-            AdminStatisticsDto dto = entity.toDto();
-            log.info("[DB Fallback] DB에서 통계 데이터를 조회하여 복원함 - key: {}", key);
-
-            // ✅ Redis 재캐싱 (TTL: 30일)
-            redisUtil.save(key, dto, StatisticsConstants.STATISTICS_CACHE_TTL);
-
-            return dto;
-
-          } catch (Exception e) {
-            log.error("[DB Fallback 실패] 통계 JSON 역직렬화 실패 - key: {}", key, e);
-            throw new CustomException(StatisticsErrorCode.STATISTICS_DESERIALIZATION_FAILED);
-          }
-        })
-        .orElseThrow(() -> {
-          log.error("[DB Fallback 실패] DB에 해당 날짜 통계 데이터 없음 - key: {}", key);
-          return new CustomException(StatisticsErrorCode.STATISTICS_NOT_FOUND);
-        });
+    return storageService.loadOrThrow(year, month, day);
   }
 
-
   /**
-   * 스케줄러나 초기화 시에 호출: 통계 생성 → 저장
+   * Redis → DB 저장 (스케줄러 호출 시)
    */
   public void generateAndStoreStatistics(int year, Integer month, Integer day) {
     AdminStatisticsDto dto = generateStatistics(year, month, day);
-    saveStatisticsToRedisAndDb(dto);
+    storageService.save(dto);
   }
 
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
@@ -19,6 +19,11 @@ import com.homeaid.statistics.dto.ReservationStatsDto;
 import com.homeaid.statistics.dto.SettlementStatsDto;
 import com.homeaid.statistics.dto.UserStatsDto;
 import com.homeaid.statistics.exception.StatisticsErrorCode;
+import com.homeaid.statistics.provider.ManagerRatingStatisticsProvider;
+import com.homeaid.statistics.provider.MatchingStatisticsProvider;
+import com.homeaid.statistics.provider.PaymentStatisticsProvider;
+import com.homeaid.statistics.provider.ReservationStatisticsProvider;
+import com.homeaid.statistics.provider.SettlementStatisticsProvider;
 import com.homeaid.statistics.provider.UserStatisticsProvider;
 import com.homeaid.statistics.repository.StatisticsRepository;
 import com.homeaid.util.RedisKeyFactory;
@@ -33,10 +38,12 @@ import org.springframework.stereotype.Service;
 public class AdminStatisticsServiceImpl implements AdminStatisticsService {
 
   private final UserStatisticsProvider userStatisticsProvider;
-  private final PaymentRepository paymentRepository;
-  private final ReservationRepository reservationRepository;
-  private final SettlementRepository settlementRepository;
-  private final MatchingRepository matchingRepository;
+  private final PaymentStatisticsProvider paymentStatisticsProvider;
+  private final ReservationStatisticsProvider reservationStatisticsProvider;
+  private final MatchingStatisticsProvider matchingStatisticsProvider;
+  private final SettlementStatisticsProvider settlementStatisticsProvider;
+  private final ManagerRatingStatisticsProvider managerRatingStatisticsProvider;
+
   private final ReviewRepository reviewRepository; // 매니저 전체 평균 평점, 매니저 대상 총 리뷰 수
 
   private final RedisUtil redisUtil;
@@ -48,91 +55,28 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
   }
 
   @Override
-  public SettlementStatsDto getSettlementStats(int year, Integer month, Integer day) {
-    return SettlementStatsDto.builder()
-        .year(year).month(month).day(day)
-        .requestedCount(settlementRepository.countRequested(year, month, day))
-        .paidCount(settlementRepository.countPaid(year, month, day))
-        .build();
-  }
-
-  @Override
   public PaymentStatsDto getPaymentStats(int year, Integer month, Integer day) {
-    long total = paymentRepository.sumPayments(year, month, day);
-    long canceled = paymentRepository.sumCanceledPayments(year, month, day);
-    long paymentCount = paymentRepository.countPayments(year, month, day);
-    long cancelCount = paymentRepository.countCanceledPayments(year, month, day);
-
-    PaymentStatsDto.PaymentStatsDtoBuilder builder = PaymentStatsDto.builder()
-        .year(year).month(month).day(day)
-        .totalAmount(total)
-        .cancelAmount(canceled)
-        .paymentCount(paymentCount)
-        .cancelCount(cancelCount);
-
-    // 월 통계일 경우에만 수단별 통계 추가
-    if (month != null && day == null) {
-      applyPaymentMethodSums(builder, year, month);
-    }
-
-    return builder.build();
-  }
-
-  private void applyPaymentMethodSums(PaymentStatsDto.PaymentStatsDtoBuilder builder, int year, int month) {
-    Object result = paymentRepository.findPaymentMethodSums(year, month);
-    if (result instanceof Object[] values && values.length == 3) {
-      builder.card(((Number) values[0]).longValue());
-      builder.transfer(((Number) values[1]).longValue());
-      builder.cash(((Number) values[2]).longValue());
-    } else {
-      builder.card(0L).transfer(0L).cash(0L);
-    }
+    return paymentStatisticsProvider.generate(year, month, day);
   }
 
   @Override
   public ReservationStatsDto getReservationStats(int year, Integer month, Integer day) {
-    long reservationCount = reservationRepository.countReservations(year, month, day);
-    long cancelledCount = reservationRepository.countCancelledReservations(year, month, day);
-    Double avgMinutes = reservationRepository.getAverageProcessingMinutes(year, month, day);
-    long completed = reservationRepository.countCompletedReservations(year, month, day);
-
-    double successRate = (reservationCount > 0)
-        ? (completed * 100.0 / reservationCount)
-        : 0.0;
-
-    return ReservationStatsDto.builder()
-        .year(year).month(month).day(day)
-        .reservationCount(reservationCount)
-        .cancelledCount(cancelledCount)
-        .avgProcessingMinutes(avgMinutes != null ? avgMinutes : 0.0)
-        .reservationSuccessRate(successRate)
-        .build();
+    return reservationStatisticsProvider.generate(year, month, day);
   }
 
   @Override
   public MatchingStatsDto getMatchingStats(int year, Integer month, Integer day) {
-    long success = matchingRepository.countConfirmedMatchings(year, month, day);
-    long fail = matchingRepository.countFailedOrCancelledMatchings(year, month, day);
-    long total = matchingRepository.countTotalMatchings(year, month, day);
+    return matchingStatisticsProvider.generate(year, month, day);
+  }
 
-    return MatchingStatsDto.builder()
-        .year(year).month(month).day(day)
-        .successCount(success)
-        .failCount(fail)
-        .totalCount(total)
-        .build();
+  @Override
+  public SettlementStatsDto getSettlementStats(int year, Integer month, Integer day) {
+    return settlementStatisticsProvider.generate(year, month, day);
   }
 
   @Override
   public ManagerRatingStatsDto getManagerRatingStats(int year, Integer month, Integer day) {
-    Double avg = reviewRepository.findAvgRatingForManagers(year, month, day);
-    Long count = reviewRepository.countReviewsForManagers(year, month, day);
-
-    return ManagerRatingStatsDto.builder()
-        .year(year).month(month).day(day)
-        .avgRating(avg != null ? avg : 0.0)
-        .reviewCount(count != null ? count : 0L)
-        .build();
+    return managerRatingStatisticsProvider.generate(year, month, day);
   }
 
   /**

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
@@ -1,17 +1,25 @@
 package com.homeaid.statistics.service;
 
+import com.homeaid.exception.CustomException;
 import com.homeaid.payment.repository.PaymentRepository;
 import com.homeaid.repository.MatchingRepository;
 import com.homeaid.repository.ReservationRepository;
 import com.homeaid.repository.ReviewRepository;
 import com.homeaid.repository.UserRepository;
 import com.homeaid.settlement.repository.SettlementRepository;
+import com.homeaid.statistics.domain.StatisticsEntity;
+import com.homeaid.statistics.dto.AdminStatisticsDto;
 import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
 import com.homeaid.statistics.dto.SettlementStatsDto;
 import com.homeaid.statistics.dto.UserStatsDto;
+import com.homeaid.statistics.exception.StatisticsErrorCode;
+import com.homeaid.statistics.repository.StatisticsRepository;
+import com.homeaid.util.RedisKeyFactory;
+import com.homeaid.util.RedisUtil;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -25,6 +33,9 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
   private final SettlementRepository settlementRepository;
   private final MatchingRepository matchingRepository;
   private final ReviewRepository reviewRepository; // 매니저 전체 평균 평점, 매니저 대상 총 리뷰 수
+
+  private final RedisUtil redisUtil;
+  private final StatisticsRepository statisticsRepository;
 
   @Override
   public UserStatsDto getUserStats(int year, Integer month, Integer day) {
@@ -61,6 +72,7 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
         .paymentCount(paymentCount)
         .cancelCount(cancelCount);
 
+    // 월 통계일 경우에만 수단별 통계 추가
     if (month != null && day == null) {
       applyPaymentMethodSums(builder, year, month);
     }
@@ -123,6 +135,61 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
         .avgRating(avg != null ? avg : 0.0)
         .reviewCount(count != null ? count : 0L)
         .build();
+  }
+
+  /**
+   * 연/월/일 기준 전체 통계를 한 번에 생성하는 통합 메서드
+   * Redis 저장 또는 Fallback 처리 시 공통 호출 용도로 사용됨
+   */
+  public AdminStatisticsDto generateStatistics(int year, Integer month, Integer day) {
+    return AdminStatisticsDto.builder()
+        .year(year).month(month).day(day)
+        .userStats(getUserStats(year, month, day))
+        .paymentStats(getPaymentStats(year, month, day))
+        .reservationStats(getReservationStats(year, month, day))
+        .matchingStats(getMatchingStats(year, month, day))
+        .settlementStats(getSettlementStats(year, month, day))
+        .managerRatingStats(getManagerRatingStats(year, month, day))
+        .build();
+  }
+
+  /**
+   * 통계 데이터를 Redis에 저장하고, DB에도 백업 (매일 스케줄러에서 호출)
+   * - Redis TTL 30일
+   * - DB에는 JSON으로 저장 (StatisticsEntity)
+   */
+  public void saveStatisticsToRedisAndDb(AdminStatisticsDto dto) {
+    String key = RedisKeyFactory.buildAdminStatisticsKey(dto.getYear(), dto.getMonth(), dto.getDay());
+    redisUtil.save(key, dto, Duration.ofDays(30));
+
+    StatisticsEntity entity = StatisticsEntity.fromDto(dto);
+    statisticsRepository.save(entity);
+  }
+
+  /**
+   * Redis 조회 후 없으면 DB fallback (Controller에서 활용)
+   */
+  public AdminStatisticsDto getStatisticsOrLoad(int year, Integer month, Integer day) {
+    String key = RedisKeyFactory.buildAdminStatisticsKey(year, month, day);
+
+    // 1. Redis 우선 조회
+    Object cached = redisUtil.getObject(key);
+    if (cached instanceof AdminStatisticsDto cachedDto) {
+      return cachedDto;
+    }
+
+    // 2. Redis에 없다면 DB에서 조회
+    return statisticsRepository.findByYearAndMonthAndDay(year, month, day)
+        .map(StatisticsEntity::toDto) // 내부에서 직렬화 예외 → CustomException 처리됨
+        .orElseThrow(() -> new CustomException(StatisticsErrorCode.STATISTICS_NOT_FOUND));
+  } // 추천: 추가 모니터링을 위한 메트릭 연동 (선택사항)
+
+  /**
+   * 스케줄러나 초기화 시에 호출: 통계 생성 → 저장
+   */
+  public void generateAndStoreStatistics(int year, Integer month, Integer day) {
+    AdminStatisticsDto dto = generateStatistics(year, month, day);
+    saveStatisticsToRedisAndDb(dto);
   }
 
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsServiceImpl.java
@@ -3,14 +3,15 @@ package com.homeaid.statistics.service;
 import com.homeaid.payment.repository.PaymentRepository;
 import com.homeaid.repository.MatchingRepository;
 import com.homeaid.repository.ReservationRepository;
+import com.homeaid.repository.ReviewRepository;
 import com.homeaid.repository.UserRepository;
 import com.homeaid.settlement.repository.SettlementRepository;
+import com.homeaid.statistics.dto.ManagerRatingStatsDto;
 import com.homeaid.statistics.dto.MatchingStatsDto;
 import com.homeaid.statistics.dto.PaymentStatsDto;
 import com.homeaid.statistics.dto.ReservationStatsDto;
 import com.homeaid.statistics.dto.SettlementStatsDto;
 import com.homeaid.statistics.dto.UserStatsDto;
-import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,96 +24,44 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
   private final ReservationRepository reservationRepository;
   private final SettlementRepository settlementRepository;
   private final MatchingRepository matchingRepository;
-  //private final ReviewRepository reviewRepository;
+  private final ReviewRepository reviewRepository; // 매니저 전체 평균 평점, 매니저 대상 총 리뷰 수
 
-  // 회원 통계 - 연도/월 파라미터 공통 처리
-  private UserStatsDto buildUserStats(int year, Integer month) {
-    Double withdrawRate = userRepository.calculateWithdrawRate(year, month);
+  @Override
+  public UserStatsDto getUserStats(int year, Integer month, Integer day) {
     return UserStatsDto.builder()
         .year(year)
         .month(month)
-        .signupCount(userRepository.countSignUps(year, month))
+        .day(day)
+        .signupCount(userRepository.countSignUps(year, month, day))
         .totalUsers(userRepository.count())
-        .withdrawCount(userRepository.countWithdrawn(year, month))
-        .inactiveUserCount(userRepository.countInactiveUsers(LocalDate.now().minusMonths(6).atStartOfDay()))
-        .withdrawRate(withdrawRate != null ? withdrawRate : 0.0)
+        .withdrawCount(userRepository.countWithdrawn(year, month, day))
         .build();
   }
 
   @Override
-  public UserStatsDto getUserStats(int year) {
-    return buildUserStats(year, null);
-  }
-
-  @Override
-  public UserStatsDto getUserStatsByMonth(int year, int month) {
-    return buildUserStats(year, month);
-  }
-
-  @Override
-  public UserStatsDto getWithdrawalStatsByMonth(int year, int month) {
-    Double withdrawRate = userRepository.calculateWithdrawRate(year, month);
-    return UserStatsDto.builder()
-        .year(year)
-        .month(month)
-        .withdrawRate(withdrawRate != null ? withdrawRate : 0.0)
-        .build();
-  }
-
-  // 이탈 통계
-  @Override
-  public UserStatsDto getWithdrawalStats(int year) {
-    Double withdrawRate = userRepository.calculateWithdrawRate(year, null);
-    return UserStatsDto.builder()
-        .year(year)
-        .withdrawRate(withdrawRate != null ? withdrawRate : 0.0)
-        .build();
-  }
-
-  // 정산 통계
-  @Override
-  public SettlementStatsDto getSettlementStats(int year) {
-    return buildSettlementStats(year, null);
-  }
-
-  @Override
-  public SettlementStatsDto getSettlementStatsByMonth(int year, int month) {
-    return buildSettlementStats(year, month);
-  }
-
-  private SettlementStatsDto buildSettlementStats(int year, Integer month) {
+  public SettlementStatsDto getSettlementStats(int year, Integer month, Integer day) {
     return SettlementStatsDto.builder()
-        .year(year)
-        .month(month)
-        .requestedCount(settlementRepository.countRequested(year, month))
-        .paidCount(settlementRepository.countPaid(year, month))
+        .year(year).month(month).day(day)
+        .requestedCount(settlementRepository.countRequested(year, month, day))
+        .paidCount(settlementRepository.countPaid(year, month, day))
         .build();
   }
 
-  // 결제 통계
   @Override
-  public PaymentStatsDto getPaymentStats(int year) {
-    return buildPaymentStats(year, null);
-  }
-
-  @Override
-  public PaymentStatsDto getPaymentStatsByMonth(int year, int month) {
-    return buildPaymentStats(year, month);
-  }
-
-  // 공통 메서드
-  private PaymentStatsDto buildPaymentStats(int year, Integer month) {
-    long total = paymentRepository.sumPayments(year, month);
-    long canceled = paymentRepository.sumCanceledPayments(year, month);
+  public PaymentStatsDto getPaymentStats(int year, Integer month, Integer day) {
+    long total = paymentRepository.sumPayments(year, month, day);
+    long canceled = paymentRepository.sumCanceledPayments(year, month, day);
+    long paymentCount = paymentRepository.countPayments(year, month, day);
+    long cancelCount = paymentRepository.countCanceledPayments(year, month, day);
 
     PaymentStatsDto.PaymentStatsDtoBuilder builder = PaymentStatsDto.builder()
-        .year(year)
-        .month(month)
+        .year(year).month(month).day(day)
         .totalAmount(total)
-        .cancelAmount(canceled);
+        .cancelAmount(canceled)
+        .paymentCount(paymentCount)
+        .cancelCount(cancelCount);
 
-    // 월별일 경우만 수단별 통계 추가
-    if (month != null) {
+    if (month != null && day == null) {
       applyPaymentMethodSums(builder, year, month);
     }
 
@@ -121,52 +70,59 @@ public class AdminStatisticsServiceImpl implements AdminStatisticsService {
 
   private void applyPaymentMethodSums(PaymentStatsDto.PaymentStatsDtoBuilder builder, int year, int month) {
     Object result = paymentRepository.findPaymentMethodSums(year, month);
-
     if (result instanceof Object[] values && values.length == 3) {
-      if (values[0] instanceof Number card) builder.card(card.longValue());
-      if (values[1] instanceof Number transfer) builder.transfer(transfer.longValue());
-      if (values[2] instanceof Number cash) builder.cash(cash.longValue());
+      builder.card(((Number) values[0]).longValue());
+      builder.transfer(((Number) values[1]).longValue());
+      builder.cash(((Number) values[2]).longValue());
     } else {
       builder.card(0L).transfer(0L).cash(0L);
     }
   }
 
-  // 예약 통계
   @Override
-  public ReservationStatsDto getReservationStats(int year, Integer month) {
+  public ReservationStatsDto getReservationStats(int year, Integer month, Integer day) {
+    long reservationCount = reservationRepository.countReservations(year, month, day);
+    long cancelledCount = reservationRepository.countCancelledReservations(year, month, day);
+    Double avgMinutes = reservationRepository.getAverageProcessingMinutes(year, month, day);
+    long completed = reservationRepository.countCompletedReservations(year, month, day);
+
+    double successRate = (reservationCount > 0)
+        ? (completed * 100.0 / reservationCount)
+        : 0.0;
+
     return ReservationStatsDto.builder()
-        .year(year)
-        .month(month)
-        .reservationCount(reservationRepository.countReservationsByYearAndOptionalMonth(year, month))
-        .avgProcessingMinutes(reservationRepository.getAverageProcessingDays(year, month))
-        .build();
-  }
-
-  // 매칭 통계
-  @Override
-  public MatchingStatsDto getMatchingSuccessStats(int year, Integer month) {
-    return MatchingStatsDto.builder()
-        .year(year)
-        .month(month)
-        .successCount(matchingRepository.countConfirmedMatchings(year, month))
+        .year(year).month(month).day(day)
+        .reservationCount(reservationCount)
+        .cancelledCount(cancelledCount)
+        .avgProcessingMinutes(avgMinutes != null ? avgMinutes : 0.0)
+        .reservationSuccessRate(successRate)
         .build();
   }
 
   @Override
-  public MatchingStatsDto getMatchingFailStats(int year, Integer month) {
+  public MatchingStatsDto getMatchingStats(int year, Integer month, Integer day) {
+    long success = matchingRepository.countConfirmedMatchings(year, month, day);
+    long fail = matchingRepository.countFailedOrCancelledMatchings(year, month, day);
+    long total = matchingRepository.countTotalMatchings(year, month, day);
+
     return MatchingStatsDto.builder()
-        .year(year)
-        .month(month)
-        .failCount(matchingRepository.countFailedOrCancelledMatchings(year, month))
+        .year(year).month(month).day(day)
+        .successCount(success)
+        .failCount(fail)
+        .totalCount(total)
         .build();
   }
 
-  // 서비스 품질 통계
-//  @Override
-//  public ManagerRatingStatsDto getManagerRatingStats(int year) {
-//    return ManagerRatingStatsDto.builder()
-//        .year(year)
-//        .avgRating(reviewRepository.getAverageRatingByYear(year))
-//        .build();
-//  }
+  @Override
+  public ManagerRatingStatsDto getManagerRatingStats(int year, Integer month, Integer day) {
+    Double avg = reviewRepository.findAvgRatingForManagers(year, month, day);
+    Long count = reviewRepository.countReviewsForManagers(year, month, day);
+
+    return ManagerRatingStatsDto.builder()
+        .year(year).month(month).day(day)
+        .avgRating(avg != null ? avg : 0.0)
+        .reviewCount(count != null ? count : 0L)
+        .build();
+  }
+
 }

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageService.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageService.java
@@ -1,0 +1,11 @@
+package com.homeaid.statistics.service;
+
+import com.homeaid.statistics.dto.AdminStatisticsDto;
+
+public interface AdminStatisticsStorageService {
+
+  void save(AdminStatisticsDto dto);
+
+  AdminStatisticsDto loadOrThrow(int year, Integer month, Integer day);
+
+}

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageServiceImpl.java
@@ -26,7 +26,14 @@ public class AdminStatisticsStorageServiceImpl implements AdminStatisticsStorage
     redisUtil.save(key, dto, StatisticsConstants.STATISTICS_CACHE_TTL);
 
     StatisticsEntity entity = StatisticsEntity.fromDto(dto);
-    statisticsRepository.save(entity);
+
+    try {
+      StatisticsEntity saved = statisticsRepository.save(entity);
+      log.info("[통계 저장] DB 저장 완료 - ID: {}, 날짜: {}-{}-{}", saved.getId(), saved.getYear(), saved.getMonth(), saved.getDay());
+    } catch (Exception e) {
+      log.error("[통계 저장 실패] 예외 발생", e);
+      throw e;
+    }
   }
 
   @Override
@@ -47,7 +54,7 @@ public class AdminStatisticsStorageServiceImpl implements AdminStatisticsStorage
     }
 
     // 2. DB fallback
-    return statisticsRepository.findByYearAndMonthAndDay(year, month, day)
+    return statisticsRepository.findByDate(year, month, day)
         .map(entity -> {
           try {
             AdminStatisticsDto dto = entity.toDto();

--- a/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageServiceImpl.java
+++ b/admin/src/main/java/com/homeaid/statistics/service/AdminStatisticsStorageServiceImpl.java
@@ -1,0 +1,68 @@
+package com.homeaid.statistics.service;
+
+import com.homeaid.exception.CustomException;
+import com.homeaid.statistics.config.StatisticsConstants;
+import com.homeaid.statistics.domain.StatisticsEntity;
+import com.homeaid.statistics.dto.AdminStatisticsDto;
+import com.homeaid.statistics.exception.StatisticsErrorCode;
+import com.homeaid.statistics.repository.StatisticsRepository;
+import com.homeaid.util.RedisKeyFactory;
+import com.homeaid.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminStatisticsStorageServiceImpl implements AdminStatisticsStorageService {
+
+  private final RedisUtil redisUtil;
+  private final StatisticsRepository statisticsRepository;
+
+  @Override
+  public void save(AdminStatisticsDto dto) {
+    String key = RedisKeyFactory.buildAdminStatisticsKey(dto.getYear(), dto.getMonth(), dto.getDay());
+    redisUtil.save(key, dto, StatisticsConstants.STATISTICS_CACHE_TTL);
+
+    StatisticsEntity entity = StatisticsEntity.fromDto(dto);
+    statisticsRepository.save(entity);
+  }
+
+  @Override
+  public AdminStatisticsDto loadOrThrow(int year, Integer month, Integer day) {
+    String key = RedisKeyFactory.buildAdminStatisticsKey(year, month, day);
+
+    // 1. Redis 조회
+    Object cached = redisUtil.getObject(key);
+    if (cached instanceof AdminStatisticsDto cachedDto) {
+      log.info("[캐시 HIT] Redis에서 통계 데이터 조회 - key: {}", key);
+      return cachedDto;
+    }
+
+    if (cached != null) {
+      log.warn("[캐시 MISS] 타입 불일치 - key: {}", key);
+    } else {
+      log.warn("[캐시 MISS] Redis에 없음 - key: {}", key);
+    }
+
+    // 2. DB fallback
+    return statisticsRepository.findByYearAndMonthAndDay(year, month, day)
+        .map(entity -> {
+          try {
+            AdminStatisticsDto dto = entity.toDto();
+            log.info("[DB Fallback] DB에서 통계 데이터를 조회하여 복원 - key: {}", key);
+            redisUtil.save(key, dto, StatisticsConstants.STATISTICS_CACHE_TTL);
+            return dto;
+          } catch (Exception e) {
+            log.error("[역직렬화 실패] - key: {}", key, e);
+            throw new CustomException(StatisticsErrorCode.STATISTICS_DESERIALIZATION_FAILED);
+          }
+        })
+        .orElseThrow(() -> {
+          log.error("[DB MISS] 통계 데이터 없음 - key: {}", key);
+          return new CustomException(StatisticsErrorCode.STATISTICS_NOT_FOUND);
+        });
+  }
+
+}

--- a/global/src/main/java/com/homeaid/util/RedisKeyFactory.java
+++ b/global/src/main/java/com/homeaid/util/RedisKeyFactory.java
@@ -9,4 +9,11 @@ public class RedisKeyFactory {
   public static String buildBlacklistTokenKey(String accessToken) {
     return "BL:" + accessToken;
   }
+
+  public static String buildAdminStatisticsKey(int year, Integer month, Integer day) {
+    StringBuilder sb = new StringBuilder("admin:statistics:").append(year);
+    if (month != null) sb.append(":").append(String.format("%02d", month));
+    if (day != null) sb.append(":").append(String.format("%02d", day));
+    return sb.toString();
+  }
 }

--- a/global/src/main/java/com/homeaid/util/RedisUtil.java
+++ b/global/src/main/java/com/homeaid/util/RedisUtil.java
@@ -73,4 +73,15 @@ public class RedisUtil {
       return false;
     }
   }
+
+  // 스케줄러 중복 실행 방지를 위한 분산 락
+  public boolean setIfAbsent(String key, String value, Duration timeout) {
+    try {
+      Boolean result = redisTemplate.opsForValue().setIfAbsent(key, value, timeout);
+      return Boolean.TRUE.equals(result);
+    } catch (Exception e) {
+      log.error("Redis Lock 설정 실패 - Key: {}", key, e);
+      return false;
+    }
+  }
 }

--- a/payment/src/main/java/com/homeaid/payment/domain/Payment.java
+++ b/payment/src/main/java/com/homeaid/payment/domain/Payment.java
@@ -18,6 +18,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -59,6 +61,21 @@ public class Payment {
   @Builder.Default
   @Column(nullable = false)
   private Integer refundedAmount = 0;  // 부분환불 누적 금액
+
+  @Column(nullable = false)
+  private Integer netAmount; // 초기값은 amount - refundedAmount
+
+  @PrePersist
+  @PreUpdate
+  private void updateNetAmount() {
+    if (amount != null && refundedAmount != null) {
+      this.netAmount = amount - refundedAmount;
+    }
+  }
+
+  public int getNetAmount() {
+    return this.amount - this.refundedAmount;
+  }
 
   // 결제에 대해 전체 환불 처리
   public void markRefunded() {

--- a/payment/src/main/java/com/homeaid/payment/dto/response/PaymentResponseDto.java
+++ b/payment/src/main/java/com/homeaid/payment/dto/response/PaymentResponseDto.java
@@ -37,17 +37,11 @@ public class PaymentResponseDto {
   @Schema(description = "고객 이름", example = "박호일")
   private String customerName;
 
-  public static PaymentResponseDto toDto(Payment payment, String customerName) {
-    return PaymentResponseDto.builder()
-        .id(payment.getId())
-        .reservationId(payment.getReservation().getId())
-        .amount(payment.getAmount())
-        .paymentMethod(payment.getPaymentMethod())
-        .status(payment.getStatus())
-        .paidAt(payment.getPaidAt())
-        .customerName(customerName)
-        .build();
-  }
+  @Schema(description = "환불 금액", example = "10000")
+  private Integer refundedAmount;
+
+  @Schema(description = "실 결제 금액", example = "40000")
+  private Integer netAmount;
 
   public static PaymentResponseDto toDto(Payment payment) {
     return PaymentResponseDto.builder()
@@ -57,6 +51,22 @@ public class PaymentResponseDto {
         .paymentMethod(payment.getPaymentMethod())
         .status(payment.getStatus())
         .paidAt(payment.getPaidAt())
+        .refundedAmount(payment.getRefundedAmount())
+        .netAmount(payment.getNetAmount())
+        .build();
+  }
+
+  public static PaymentResponseDto toDto(Payment payment, String customerName) {
+    return PaymentResponseDto.builder()
+        .id(payment.getId())
+        .reservationId(payment.getReservation().getId())
+        .amount(payment.getAmount())
+        .paymentMethod(payment.getPaymentMethod())
+        .status(payment.getStatus())
+        .paidAt(payment.getPaidAt())
+        .customerName(customerName)
+        .refundedAmount(payment.getRefundedAmount())
+        .netAmount(payment.getNetAmount())
         .build();
   }
 }

--- a/payment/src/main/java/com/homeaid/payment/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/homeaid/payment/repository/PaymentRepository.java
@@ -23,13 +23,37 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE p.status = 'PAID'")
   long sumAllPaymentAmounts();
 
-  // 총 결제 금액 (연간/월간)
-  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE YEAR(p.paidAt) = :year AND (:month IS NULL OR MONTH(p.paidAt) = :month) AND p.status = 'PAID'")
-  long sumPayments(@Param("year") int year, @Param("month") Integer month);
+  // 총 결제 금액 (연간/월간/일간)
+  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p " +
+      "WHERE YEAR(p.paidAt) = :year " +
+      "AND (:month IS NULL OR MONTH(p.paidAt) = :month) " +
+      "AND (:day IS NULL OR DAY(p.paidAt) = :day) " +
+      "AND p.status = 'PAID'")
+  long sumPayments(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day);
 
-  // 취소 금액 (연간/월간)
-  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE YEAR(p.paidAt) = :year AND (:month IS NULL OR MONTH(p.paidAt) = :month) AND p.status IN ('CANCELED', 'REFUNDED', 'PARTIAL_REFUNDED')")
-  long sumCanceledPayments(@Param("year") int year, @Param("month") Integer month);
+  // 취소 금액 (연간/월간/일간)
+  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p " +
+      "WHERE YEAR(p.paidAt) = :year " +
+      "AND (:month IS NULL OR MONTH(p.paidAt) = :month) " +
+      "AND (:day IS NULL OR DAY(p.paidAt) = :day) " +
+      "AND p.status IN ('CANCELED', 'REFUNDED', 'PARTIAL_REFUNDED')")
+  long sumCanceledPayments(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day);
+
+  // 결제 건수 (연간/월간/일간)
+  @Query("SELECT COUNT(p) FROM Payment p " +
+      "WHERE YEAR(p.paidAt) = :year " +
+      "AND (:month IS NULL OR MONTH(p.paidAt) = :month) " +
+      "AND (:day IS NULL OR DAY(p.paidAt) = :day) " +
+      "AND p.status = 'PAID'")
+  long countPayments(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day);
+
+  // 취소 건수 (연간/월간/일간)
+  @Query("SELECT COUNT(p) FROM Payment p " +
+      "WHERE YEAR(p.paidAt) = :year " +
+      "AND (:month IS NULL OR MONTH(p.paidAt) = :month) " +
+      "AND (:day IS NULL OR DAY(p.paidAt) = :day) " +
+      "AND p.status IN ('CANCELED', 'REFUNDED', 'PARTIAL_REFUNDED')")
+  long countCanceledPayments(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day);
 
   // 결제 수단별 (이건 월별 통계만 해당되므로 유지)
   @Query("SELECT " +
@@ -41,6 +65,5 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   Object findPaymentMethodSums(@Param("year") int year, @Param("month") int month);
 
   List<Payment> findAllByReservation_ManagerIdAndPaidAtBetween(Long managerId, LocalDateTime start, LocalDateTime end);
-
 
 }

--- a/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
+++ b/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
@@ -27,4 +28,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
 
   List<Refund> findAllByPaymentId(Long paymentId);
 
+  // 관리자 대시보드
+  @Query("SELECT COALESCE(SUM(r.refundAmount), 0) FROM Refund r WHERE r.status = 'COMPLETED'")
+  long sumAllRefundAmounts();
 }

--- a/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
+++ b/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
@@ -24,4 +24,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
 
   // 관리자가 환불을 시도할 때 중복 환불 여부 체크
   boolean existsByPayment_IdAndStatusIn(Long paymentId, List<RefundStatus> statuses);
+
+  List<Refund> findAllByPaymentId(Long paymentId);
+
 }

--- a/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
+++ b/payment/src/main/java/com/homeaid/payment/repository/RefundRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
@@ -31,4 +32,11 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
   // 관리자 대시보드
   @Query("SELECT COALESCE(SUM(r.refundAmount), 0) FROM Refund r WHERE r.status = 'COMPLETED'")
   long sumAllRefundAmounts();
+
+  // 관리자 대시보드 그래프
+  @Query("SELECT COALESCE(SUM(r.refundAmount), 0) FROM Refund r " +
+      "WHERE YEAR(r.processedAt) = :year AND MONTH(r.processedAt) = :month AND DAY(r.processedAt) = :day " +
+      "AND r.status = 'COMPLETED'")
+  long sumRefundsByDate(@Param("year") int year, @Param("month") int month, @Param("day") int day);
+
 }

--- a/payment/src/main/java/com/homeaid/settlement/repository/SettlementRepository.java
+++ b/payment/src/main/java/com/homeaid/settlement/repository/SettlementRepository.java
@@ -27,12 +27,25 @@ public interface SettlementRepository extends JpaRepository<Settlement, Long> {
   @Query("SELECT COALESCE(SUM(s.managerSettlementPrice), 0) FROM Settlement s")
   long sumAllSettlementAmounts();
 
-  // 정산 신청 수 (연간 또는 월간)
-  @Query("SELECT COUNT(s) FROM Settlement s WHERE YEAR(s.settledAt) = :year AND (:month IS NULL OR MONTH(s.settledAt) = :month)")
-  long countRequested(@Param("year") int year, @Param("month") Integer month);
+  // 정산 신청 수 (연/월/일)
+  @Query("""
+    SELECT COUNT(s) FROM Settlement s
+    WHERE YEAR(s.settledAt) = :year
+      AND (:month IS NULL OR MONTH(s.settledAt) = :month)
+      AND (:day IS NULL OR DAY(s.settledAt) = :day)
+  """)
+  long countRequested(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
-  // 정산 지급 완료 수 (연간 또는 월간)
-  @Query("SELECT COUNT(s) FROM Settlement s WHERE s.paidAt IS NOT NULL AND YEAR(s.paidAt) = :year AND (:month IS NULL OR MONTH(s.paidAt) = :month)")
-  long countPaid(@Param("year") int year, @Param("month") Integer month);
+  // 정산 지급 완료 수 (연/월/일)
+  @Query("""
+    SELECT COUNT(s) FROM Settlement s
+    WHERE s.paidAt IS NOT NULL
+      AND YEAR(s.paidAt) = :year
+      AND (:month IS NULL OR MONTH(s.paidAt) = :month)
+      AND (:day IS NULL OR DAY(s.paidAt) = :day)
+  """)
+  long countPaid(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
 }

--- a/reservation/src/main/java/com/homeaid/repository/MatchingRepository.java
+++ b/reservation/src/main/java/com/homeaid/repository/MatchingRepository.java
@@ -19,23 +19,37 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
 
   Page<Matching> findAllByManagerId(Long managerId, Pageable pageable);
 
-  // 성공 매칭 건수
+  // 성공 매칭 건수 (연/월/일)
   @Query("""
     SELECT COUNT(m) FROM Matching m
     WHERE m.status = 'CONFIRMED'
       AND YEAR(m.createdDate) = :year
       AND (:month IS NULL OR MONTH(m.createdDate) = :month)
+      AND (:day IS NULL OR DAY(m.createdDate) = :day)
   """)
-  long countConfirmedMatchings(@Param("year") int year, @Param("month") Integer month);
+  long countConfirmedMatchings(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
-  // 실패/취소 매칭 건수
+  // 실패/취소 매칭 건수 (연/월/일)
   @Query("""
     SELECT COUNT(m) FROM Matching m
     WHERE m.status IN ('CANCELLED', 'REJECTED')
       AND YEAR(m.createdDate) = :year
       AND (:month IS NULL OR MONTH(m.createdDate) = :month)
+      AND (:day IS NULL OR DAY(m.createdDate) = :day)
   """)
-  long countFailedOrCancelledMatchings(@Param("year") int year, @Param("month") Integer month);
+  long countFailedOrCancelledMatchings(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
+
+  // 전체 매칭 시도 수 (연/월/일)
+  @Query("""
+    SELECT COUNT(m) FROM Matching m
+    WHERE YEAR(m.createdDate) = :year
+      AND (:month IS NULL OR MONTH(m.createdDate) = :month)
+      AND (:day IS NULL OR DAY(m.createdDate) = :day)
+  """)
+  long countTotalMatchings(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
   Optional<Matching> findTopByReservationIdOrderByModifiedDateDesc(Long reservationId);
 }

--- a/review/src/main/java/com/homeaid/repository/ReviewRepository.java
+++ b/review/src/main/java/com/homeaid/repository/ReviewRepository.java
@@ -33,4 +33,28 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
   """)
   Page<Review> findByWriterRoleCondition(@Param("writerRole") UserRole writerRole, Pageable pageable);
 
+  // 매니저 전체 평균 평점
+  @Query("""
+      SELECT COALESCE(AVG(r.rating), 0)
+      FROM Review r
+      WHERE r.writerRole = 'CUSTOMER'
+        AND YEAR(r.createdAt) = :year
+        AND (:month IS NULL OR MONTH(r.createdAt) = :month)
+        AND (:day IS NULL OR DAY(r.createdAt) = :day)
+  """)
+  Double findAvgRatingForManagers(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
+
+  // 매니저 대상 총 리뷰 수
+  @Query("""
+      SELECT COUNT(r)
+      FROM Review r
+      WHERE r.writerRole = 'CUSTOMER'
+        AND YEAR(r.createdAt) = :year
+        AND (:month IS NULL OR MONTH(r.createdAt) = :month)
+        AND (:day IS NULL OR DAY(r.createdAt) = :day)
+  """)
+  Long countReviewsForManagers(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
+
 }

--- a/user/src/main/java/com/homeaid/repository/UserRepository.java
+++ b/user/src/main/java/com/homeaid/repository/UserRepository.java
@@ -18,34 +18,25 @@ public interface UserRepository extends JpaRepository<User, Long> {
   @Query("SELECT COUNT(u) FROM User u")
   long countAllUsers();
 
-  // 연도/월별 가입자 수 (월이 null이면 연도만 기준)
+  // 전체 가입자 수 (연/월/일)
   @Query("""
       SELECT COUNT(u) FROM User u
       WHERE YEAR(u.createdAt) = :year
-      AND (:month IS NULL OR MONTH(u.createdAt) = :month)
+        AND (:month IS NULL OR MONTH(u.createdAt) = :month)
+        AND (:day IS NULL OR DAY(u.createdAt) = :day)
       """)
-  long countSignUps(@Param("year") int year, @Param("month") Integer month);
+  long countSignUps(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
-  // 연도/월별 탈퇴 회원 수 (논리삭제 기준)
+  // 전체 탈퇴자 수 (연/월/일 , 논리삭제 기준)
   @Query("""
       SELECT COUNT(u) FROM User u
-      WHERE u.deleted = true AND YEAR(u.createdAt) = :year
-      AND (:month IS NULL OR MONTH(u.createdAt) = :month)
+      WHERE u.deleted = true
+        AND YEAR(u.createdAt) = :year
+        AND (:month IS NULL OR MONTH(u.createdAt) = :month)
+        AND (:day IS NULL OR DAY(u.createdAt) = :day)
       """)
-  long countWithdrawn(@Param("year") int year, @Param("month") Integer month);
+  long countWithdrawn(@Param("year") int year, @Param("month") Integer month, @Param("day") Integer day
+  );
 
-  // 연도/월별 탈퇴율 계산 (Native SQL 사용)
-  @Query(value = """
-      SELECT (COUNT(*) * 1.0 /
-        NULLIF((SELECT COUNT(*) FROM user u2 WHERE YEAR(u2.created_at) = :year
-        AND (:month IS NULL OR MONTH(u2.created_at) = :month)), 0)) * 100
-      FROM user u
-      WHERE u.deleted = true AND YEAR(u.created_at) = :year
-      AND (:month IS NULL OR MONTH(u.created_at) = :month)
-      """, nativeQuery = true)
-  Double calculateWithdrawRate(@Param("year") int year, @Param("month") Integer month);
-
-  // 장기 미접속자 수 조회 (예: 최근 6개월간 로그인 없음)
-  @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt < :threshold")
-  long countInactiveUsers(@Param("threshold") LocalDateTime threshold);
 }


### PR DESCRIPTION
## 📌 PR 목적 및 내용
- 통계 Provider별 연/월/일 조건 분기 처리를 통해 통계 단위를 명확하게 구분할 수 있도록 구조 개선
- AdminStatisticsService의 책임을 분리하여, Redis/DB 저장 및 Fallback 처리는 AdminStatisticsStorageService가 담당
- Redis TTL, 키 전략, 통계 Mapper 등 설정을 상수화하여 코드 재사용성 및 유지보수성 개선
- 관리자 대시보드 매출내역으로 수정

## ✏️ 변경 사항
- AdminStatisticsServiceImpl → Redis/DB 저장 책임 제거 → 전용 AdminStatisticsStorageService로 위임
- RedisKeyFactory → 연/월/일 단위 통계별 Redis 키 전략 정립 (admin:statistics:{yyyy}, {yyyy:MM}, {yyyy:MM:dd})
- StatisticsConstants → TTL, 락 관련 설정 상수화 (STATISTICS_CACHE_TTL, STATISTICS_LOCK_TTL)
- AdminStatisticsController → 일간 단위 외에도 월간/연간 확장 고려 가능 구조로 리팩토링 기반 마련
- 관리자 대시보드에서 매출내역과 그래프가 보이도록 수정
- 결제금액에서 환불금액을 반영하여 실제 금액이 보이도록 수정

## 🔍 참고사항
- 현재는 일간(Daily) 기준 통계 조회를 기본으로 제공 → 이후 월간/연간 확장 시 Provider 내부 메서드만 추가 구현하면 구조적으로 대응 가능
- Redis 캐시 미스 발생 시 DB fallback → 캐시 재저장 로직도 분리 적용됨
- 각 Provider는 통계 생성 책임만 가지며, 저장/조회 책임은 가지지 않도록 단일 책임 원칙(SRP)을 따름

## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작하나요?
- [ ] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- #170