### PR TITLE
fix: unread alert else 누락 수정

### DIFF
--- a/notification/src/main/java/com/homeaid/domain/enumerate/AlertType.java
+++ b/notification/src/main/java/com/homeaid/domain/enumerate/AlertType.java
@@ -26,6 +26,7 @@ public enum AlertType {
 
     // 시스템 관련
     PAYMENT_COMPLETED("결제가 완료되었습니다"),
+    MANAGER_REVIEW_RECEIVED("고객님으로부터 새로운 리뷰를 받았습니다"),
     REVIEW_REQUESTED("리뷰 작성 요청");
 
     private final String defaultMessage;

--- a/notification/src/main/java/com/homeaid/service/NotificationService.java
+++ b/notification/src/main/java/com/homeaid/service/NotificationService.java
@@ -34,13 +34,11 @@ public class NotificationService {
     //연결시 사용자의 읽지 않은 알림들
     @Transactional(readOnly = true)
     public List<Notification> getUnReadAlerts(Long userId, UserRole userRole) {
-        List<Notification> notifications = null;
         if (UserRole.ADMIN.equals(userRole)) {
-            notifications = notificationRepository.findByTargetRoleAndStatusOrderByCreatedAtDesc(userRole, NotificationStatus.UNREAD);
+            return notificationRepository.findByTargetRoleAndStatusOrderByCreatedAtDesc(userRole, NotificationStatus.UNREAD);
+        } else {
+            return notificationRepository.findByTargetIdAndStatusOrderByCreatedAtDesc(userId, NotificationStatus.UNREAD);
         }
-        notifications = notificationRepository.findByTargetIdAndStatusOrderByCreatedAtDesc(userId, NotificationStatus.UNREAD);
-
-        return Optional.ofNullable(notifications).orElse(Collections.emptyList());
     }
 
     @Transactional

--- a/notification/src/main/java/com/homeaid/service/SseNotificationService.java
+++ b/notification/src/main/java/com/homeaid/service/SseNotificationService.java
@@ -161,7 +161,7 @@ public class SseNotificationService {
                         .name("ping")
                         .data(System.currentTimeMillis()));
             } catch (IOException ignored) {
-                emitter.complete();
+                removeConnection(userId);
             }
         });
     }

--- a/review/build.gradle.kts
+++ b/review/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     implementation(project(":user"))
     implementation(project(":global"))
+    implementation(project(":notification"))
     implementation(project(":reservation"))
 
 

--- a/review/src/main/java/com/homeaid/service/ReviewServiceImpl.java
+++ b/review/src/main/java/com/homeaid/service/ReviewServiceImpl.java
@@ -1,6 +1,8 @@
 package com.homeaid.service;
 
+import com.homeaid.domain.enumerate.AlertType;
 import com.homeaid.domain.enumerate.UserRole;
+import com.homeaid.dto.RequestAlert;
 import com.homeaid.reservation.domain.Reservation;
 import com.homeaid.domain.Review;
 import com.homeaid.reservation.domain.enumerate.ReservationStatus;
@@ -11,7 +13,6 @@ import com.homeaid.exception.ReviewErrorCode;
 import com.homeaid.matching.repository.MatchingRepository;
 import com.homeaid.reservation.repository.ReservationRepository;
 import com.homeaid.repository.ReviewRepository;
-import com.homeaid.reservation.service.ReservationService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,7 @@ public class ReviewServiceImpl implements ReviewService {
   private final ReservationRepository reservationRepository;
   private final MatchingRepository matchingRepository;
   private final UserRatingUpdateService userRatingUpdateService;
+  private final NotificationPublisher notificationPublisher;
 
   @Transactional
   @Override
@@ -49,7 +51,9 @@ public class ReviewServiceImpl implements ReviewService {
     userRatingUpdateService.updateRating(savedReview.getTargetId(),
         savedReview.getWriterRole());
 
-    //Todo 매니저 찜 기능
+    RequestAlert requestAlert = RequestAlert.createAlert(AlertType.MANAGER_REVIEW_RECEIVED,
+            validatedReservation.getManagerId(), UserRole.MANAGER, savedReview.getId(), null);
+    notificationPublisher.publishNotification(requestAlert);
 
     return savedReview;
   }


### PR DESCRIPTION
## 📌 PR 목적 및 내용
안읽는 알람 api 서비스에서 else 누락으로 관리자가 다른 메서드로 알람을 조회하였음.

## ✏️ 변경 사항


## 📸 스크린샷 (선택사항)
- UI 변경이나 기능 추가 시 스크린샷을 첨부해주세요.

## ✅ 체크리스트
- [X] 코드가 정상적으로 동작하나요?
- [x] 기존 코드와 충돌이 없나요?
- [ ] 테스트를 통과했나요?
- [ ] 문서 업데이트가 필요한가요?

## 🔗 관련 이슈 (선택사항)
- 연관된 이슈가 있다면 연결해주세요. 예시: #12